### PR TITLE
Only match digits for the bug number

### DIFF
--- a/phlay
+++ b/phlay
@@ -200,7 +200,7 @@ class Commit(Cached):
         self.parent_hashes = self.parent_hashes.split()
 
         # Compute more info based on the commit message etc.
-        bugmatch = re.search(r'bug\s+(\S+)', self.subject, re.I)
+        bugmatch = re.search(r'bug\s+(\d+)', self.subject, re.I)
         self.bug = bugmatch and Bug(bugmatch.group(1))
 
         # Parse the reviewer list


### PR DESCRIPTION
I write my bug summaries like "Bug 123456, part 1 - Do some stuff.". With the way the bug number finding code currently works, the bug number ends up as "123456,". Changing this regexp from matching any characters to only matching digits seems to fix this.