### PR TITLE
Parse diffs locally, and other improvements

### DIFF
--- a/phlay
+++ b/phlay
@@ -759,7 +759,7 @@ def process_args(args):
             label('Set Bug',
                   f"Bug {commit.bug.bugno}",
                   f"{style.bold}[{buginfo['status']}]{style.reset}",
-                  f"{style.italic}{buginfo['summary']}{style.reset}")
+                  f"{buginfo['summary']}")
 
         # Add any reviewers not in the original commit
         to_add = []

--- a/phlay
+++ b/phlay
@@ -427,7 +427,7 @@ class Blob(Cached):
         if self.is_null():
             return None
         if self._body is None:
-            self._body = check_output('git', 'cat-file', 'blob', self.hash)
+            self._body = check_output(['git', 'cat-file', 'blob', self.hash])
         return self._body
 
 

--- a/phlay
+++ b/phlay
@@ -8,6 +8,7 @@ import curses
 import base64
 import socket
 import difflib
+import mimetypes
 
 from http.client import HTTPSConnection
 from urllib.parse import urlencode, urlparse
@@ -158,7 +159,8 @@ class Diff:
             metadata = {}
             for upload in self.uploads:
                 metadata[f'{upload["type"]}:binary-phid'] = upload['phid']
-                metadata[f'{upload["type"]}:file-size'] = len(upload['value'])
+                metadata[f'{upload["type"]}:file:size'] = len(upload['value'])
+                metadata[f'{upload["type"]}:file:mime-type'] = upload['mime']
 
             # Translate hunks
             hunks = [{
@@ -185,8 +187,8 @@ class Diff:
                 'oldProperties': old_props,
                 'newProperties': cur_props,
                 'commitHash': commit.hg_hash,
-                'type': self.kind,
-                'fileType': self.file_type,
+                'type': self.kind.value,
+                'fileType': self.file_type.value,
                 'hunks': hunks,
             }
 
@@ -199,6 +201,25 @@ class Diff:
         MOVE_HERE = 6
         COPY_HERE = 7
         MULTICOPY = 8
+
+        def short(self):
+            if self == self.ADD:
+                return 'A '
+            elif self == self.CHANGE:
+                return 'M '
+            elif self == self.DELETE:
+                return 'D '
+            elif self == self.MOVE_AWAY:
+                return 'R>'
+            elif self == self.MOVE_HERE:
+                return '>R'
+            elif self == self.COPY_AWAY:
+                return 'C>'
+            elif self == self.COPY_HERE:
+                return '>C'
+            elif self == self.MULTICOPY:
+                return 'C*'
+
 
     class FileType(Enum):
         TEXT = 1
@@ -214,7 +235,7 @@ class Diff:
         self.changes = {}
         self.phid = None
 
-        raw = check_output(['git', 'diff-tree', '-r', '--raw', '-z',
+        raw = check_output(['git', 'diff-tree', '-r', '--raw', '-z', '-M', '-C',
                             '--no-abbrev', commit.commit_hash]).decode()
         # Strip the prefix sha1, and remove the trailing null
         for c in raw[:-1].split('\0:')[1:]:
@@ -257,14 +278,27 @@ class Diff:
         # Detect if we're binary, and generate a unified diff
         change.binary = b'\0' in a_body or b'\0' in b_body
         if change.binary:
+            a_mime = mimetypes.guess_type(a_path)[0] or ''
+            b_mime = mimetypes.guess_type(b_path)[0] or ''
             change.uploads = [
-                {'type': 'old', 'value': a_body, 'phid': None},
-                {'type': 'new', 'value': b_body, 'phid': None},
+                {'type': 'old', 'value': a_body, 'mime': a_mime, 'phid': None},
+                {'type': 'new', 'value': b_body, 'mime': b_mime, 'phid': None},
             ]
-            change.hunks = []
-            change.file_type = self.FileType.BINARY
+            if a_mime.startswith('image/') or b_mime.startswith('image/'):
+                change.file_type = self.FileType.IMAGE
+            else:
+                change.file_type = self.FileType.BINARY
+        elif a_blob == b_blob:
+            # Identical blobs have no diff, and thus get a fake hunk.
+            lines = a_body.decode().splitlines()
+            change.hunks = [self.Hunk(
+                old_off=1, old_len=len(lines),
+                new_off=1, new_len=len(lines),
+                added=0, deleted=0,
+                corpus='\n'.join(f" {l}" for l in lines),
+            )]
+            change.file_type = self.FileType.TEXT
         else:
-            change.uploads = []
             # Generate the diff using difflib
             [hdr, *corpus] = list(difflib.unified_diff(
                 a_body.decode().splitlines(),
@@ -273,10 +307,10 @@ class Diff:
             ))[2:]
 
             # Match on the hunk line
-            m = re.match(r'@@ -(\d+),(\d+) \+(\d+),(\d+) @@', hdr, re.I)
+            m = re.match(r'@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@', hdr, re.I)
             change.hunks = [self.Hunk(
-                old_off=int(m.group(1)), old_len=int(m.group(2)),
-                new_off=int(m.group(3)), new_len=int(m.group(4)),
+                old_off=int(m.group(1)), old_len=int(m.group(2) or 1),
+                new_off=int(m.group(3)), new_len=int(m.group(4) or 1),
                 added=sum(1 for l in corpus if l[0] == '+'),
                 deleted=sum(1 for l in corpus if l[0] == '-'),
                 corpus='\n'.join(corpus),
@@ -294,13 +328,15 @@ class Diff:
 
         elif kind_l[0] == 'M':
             change.kind = self.Kind.CHANGE
-            change.old_mode = a_mode
-            change.new_mode = b_mode
+            if a_mode != b_mode:
+                change.old_mode = a_mode
+                change.new_mode = b_mode
 
         elif kind_l[0] == 'R':
             change.kind = self.Kind.MOVE_HERE
-            change.old_mode = a_mode
-            change.new_mode = b_mode
+            if a_mode != b_mode:
+                change.old_mode = a_mode
+                change.new_mode = b_mode
 
             change.old_path = a_path
             old = self.change_for(change.old_path)
@@ -312,8 +348,9 @@ class Diff:
 
         elif kind_l[0] == 'C':
             change.kind = self.Kind.COPY_HERE
-            change.old_mode = a_mode
-            change.new_mode = b_mode
+            if a_mode != b_mode:
+                change.old_mode = a_mode
+                change.new_mode = b_mode
 
             change.old_path = a_path
             old = self.change_for(change.old_path)
@@ -331,15 +368,15 @@ class Diff:
     def do_uploads(self, style, conduit):
         for change in self.changes.values():
             for upload in change.uploads:
-                print(f"{style.yellow}{style.bold}Uploading Binary{style.reset}",
-                      f"{change.cur_path}")
+                print(style.bold_yellow('Uploading Binary'),
+                      f"{change.cur_path} [{upload['type']}] {upload['mime']}")
                 data_base64 = base64.standard_b64encode(upload['value'])
                 upload['phid'] = conduit.do('file.upload',
                                             data_base64=data_base64.decode())
                 print(f"    File PHID: {upload['phid']}")
 
     def do_publish(self, style, conduit):
-        print(style.bold_yellow('Publishing Patch'), f"{self.commit.summary}")
+        print(style.bold_yellow('Publishing Patch'), f"{self.commit.subject}")
         changes = [change.to_conduit(self.commit)
                    for change in self.changes.values()]
         diff = conduit.do('differential.creatediff',
@@ -367,8 +404,8 @@ class Diff:
                            'author': self.commit.author_name,
                            'authorEmail': self.commit.author_email,
                            'time': int(self.commit.unix_date),
-                           'summary': self.commit.summary,
-                           'message': self.commit.raw_body,
+                           'summary': self.commit.subject,
+                           'message': self.commit.raw_body.strip(),
                            'commit': self.commit.hg_hash,
                            'tree': self.commit.tree_hash,
                            'parents': [self.commit.parent().hg_hash],
@@ -744,10 +781,10 @@ def process_args(args):
         summary = ''
         longest = max(len(name) for name in diff.changes)
         for path, change in diff.changes.items():
-            summary += f"{path:<{longest}} "
+            summary += f"{change.kind.short()} {path:<{longest}} "
             summary += style.bold(f"+{change.added}, -{change.deleted}\n")
         summary += style.bold(f"{len(diff.changes)} files")
-        summary += f" (+{diff.added}, -{diff.deleted})"
+        summary += style.bold(f" (+{diff.added}, -{diff.deleted})")
         label('Changes', summary)
 
         # Title Updates
@@ -783,7 +820,7 @@ def process_args(args):
         for reviewer in commit.reviewers:
             reviewerinfo = reviewer.info(conduit)
             if reviewerinfo['phid'] not in rev_phids:
-                to_add.append(reviewerinfo['phid'])
+                to_add.append(f"blocking({reviewerinfo['phid']})")
                 if reviewerinfo['type'] == 'USER':
                     label('Add Reviewer',
                           reviewerinfo['fields']['realName'],
@@ -811,7 +848,7 @@ def process_args(args):
     # Perform the commit rewriting
     parent = start
     for idx, commit in enumerate(push):
-        print(style.bold_yellow(f"Requesting Review"), f"{commit.summary}")
+        print(style.bold_yellow(f"Requesting Review"), f"{commit.subject}")
 
         # Add a 'Depends on' entry to the transaction if needed
         if idx > 0:
@@ -846,8 +883,8 @@ def process_args(args):
 
     # Rewrite 'ref'
     if initial_ref != parent:
-        print(style.bold_yellow(f"Updating {ref}"))
-        print(f"  {initial_ref.abbrev} => {parent.abbrev}")
+        print(style.bold_yellow(f"Updating Ref"), ref)
+        print(f"    {initial_ref.abbrev} => {parent.abbrev}")
         check_call([
             'git', 'update-ref', '-m', 'phlay: rewrite',
             ref, parent.commit_hash, initial_ref.commit_hash,

--- a/phlay
+++ b/phlay
@@ -13,6 +13,9 @@ import json
 import curses
 import base64
 import socket
+import difflib
+from collections import namedtuple
+from enum import Enum
 
 
 NULL_SHA1 = '0' * 40
@@ -32,6 +35,8 @@ class Style:
     def __getattr__(self, name):
         if not self.styled:
             return ''
+        if '_' in name:
+            return ''.join(getattr(self, n) for n in name.split('_'))
         name = self.SUGAR.get(name, name)
         if name in self.COLORS:
             num = getattr(curses, 'COLOR_' + name.upper())
@@ -103,207 +108,223 @@ class Conduit:
         return resp['data'][0]
 
 
-class Hunk:
-    def __init__(self, a_offset, a_length, b_offset, b_length):
-        self.a_offset = a_offset
-        self.a_length = a_length
-        self.b_offset = b_offset
-        self.b_length = b_length
-        self.corpus = []
-
-    def to_conduit(self, _conduit):
-        return {
-            'oldOffset': self.a_offset,
-            'oldLength': self.a_length,
-            'newOffset': self.b_offset,
-            'newLength': self.b_length,
-            'corpus': '\n'.join(self.corpus),
-        }
-
-
-class Change:
-    """Individual file change as part of a changeset"""
-    # I just love magic numbers~!
-    TYPE_ADD        = 1
-    TYPE_CHANGE     = 2
-    TYPE_DELETE     = 3
-
-    # XXX(nika): Add support for moves/copies
-    TYPE_MOVE_AWAY  = 4
-    TYPE_COPY_AWAY  = 5
-    TYPE_MOVE_HERE  = 6
-    TYPE_COPY_HERE  = 7
-    TYPE_MULTICOPY  = 8
-
-    FILE_TEXT       = 1
-    FILE_IMAGE      = 2
-    FILE_BINARY     = 3
-    FILE_DIRECTORY  = 4
-    FILE_SYMLINK    = 5
-    FILE_DELETED    = 6
-    FILE_NORMAL     = 7
-
-    def __init__(self, a_mode, b_mode, a_sha, b_sha, kind, a_path, b_path):
-        self.a_mode = a_mode
-        self.b_mode = b_mode
-        self.a_blob = Blob(a_sha)
-        self.b_blob = Blob(b_sha)
-        self.kind = kind
-        self.a_path = a_path
-        self.b_path = b_path
-
-        # Information about diff state
-        self.hunks = []
-        self.added = 0
-        self.removed = 0
-        self.binary = False
-
-    def to_conduit(self, conduit):
-        # Upload binary blobs if necessary.
-        metadata = {}
-        if self.binary and self.b_blob.body() is not None:
-            data_base64 = base64.standard_b64encode(self.b_blob.body()).decode()
-            binary_phid = conduit.do('file.upload', data_base64=data_base64)
-            metadata = {
-                'old:file-size': len(self.a_blob.body()),
-                'new:file-size': len(self.b_blob.body()),
-                'new:binary-phid': binary_phid,
-                # XXX(nika): Guess mime type?
-            }
-
-        old_props = { 'unix:filemode': self.a_mode } if self.a_path else {}
-        new_props = { 'unix:filemode': self.b_mode } if self.b_path else {}
-
-        return {
-            'metadata': metadata,
-            'oldProperties': old_props,
-            'newProperties': new_props,
-            'oldPath': self.a_path,
-            'currentPath': self.b_path,
-            'addLines': self.added,
-            'delLines': self.removed,
-            'type': self.kind,
-            'fileType': self.FILE_BINARY if self.binary else self.FILE_TEXT,
-            'hunks': [hunk.to_conduit(conduit) for hunk in self.hunks],
-        }
-
-
 class Diff:
     """simple diff parser"""
+
+    Hunk = namedtuple('Hunk', ['old_off', 'old_len', 'new_off', 'new_len',
+                               'added', 'deleted', 'corpus'])
+
+    class Change:
+        def __init__(self, path):
+            self.old_mode = None
+            self.cur_mode = None
+            self.old_path = None
+            self.cur_path = path
+            self.away_paths = []
+            self.kind = Diff.Kind.CHANGE
+            self.binary = False
+            self.file_type = Diff.FileType.TEXT
+            self.uploads = []
+            self.hunks = []
+
+        @property
+        def added(self):
+            return sum(hunk.added for hunk in self.hunks)
+
+        @property
+        def deleted(self):
+            return sum(hunk.deleted for hunk in self.hunks)
+
+        def to_conduit(self, commit):
+            # Record upload information
+            metadata = {}
+            for upload in self.uploads:
+                metadata[f'{upload["type"]}:binary-phid'] = upload['phid']
+                metadata[f'{upload["type"]}:file-size'] = len(upload['value'])
+
+            # Translate hunks
+            hunks = [{
+                'oldOffset': hunk.old_off,
+                'oldLength': hunk.old_len,
+                'newOffset': hunk.new_off,
+                'newLength': hunk.new_len,
+                # isMissingOldNewline
+                # isMissingNewNewline
+                'corpus': hunk.corpus,
+            } for hunk in self.hunks]
+
+            old_props = {'unix:filemode': self.old_mode} if self.old_mode else {}
+            cur_props = {'unix:filemode': self.cur_mode} if self.cur_mode else {}
+
+            added = sum(hunk.added for hunk in self.hunks)
+            deleted = sum(hunk.deleted for hunk in self.hunks)
+
+            return {
+                'metadata': metadata,
+                'oldPath': self.old_path,
+                'currentPath': self.cur_path,
+                'awayPaths': self.away_paths,
+                'oldProperties': old_props,
+                'newProperties': cur_props,
+                'commitHash': commit.hg_hash,
+                'type': self.kind,
+                'fileType': self.file_type,
+                'hunks': hunks,
+            }
+
+    class Kind(Enum):
+        ADD = 1
+        CHANGE = 2
+        DELETE = 3
+        MOVE_AWAY = 4
+        COPY_AWAY = 5
+        MOVE_HERE = 6
+        COPY_HERE = 7
+        MULTICOPY = 8
+
+    class FileType(Enum):
+        TEXT = 1
+        IMAGE = 2 # XXX(nika): Generate this sometimes?
+        BINARY = 3
+        DIRECTORY = 4 # Should never show up...
+        SYMLINK = 5 # XXX(nika): Support symlinks (do we care?)?
+        DELETED = 6
+        NORMAL = 7
+
     def __init__(self, commit):
         self.commit = commit
-        self.changes = []
+        self.changes = {}
+        self.phid = None
 
-        hash_to_changes = {}
+        raw = check_output(['git', 'diff-tree', '-r', '--raw', '-z',
+                            '--no-abbrev', commit.commit_hash]).decode()
+        # Strip the prefix sha1, and remove the trailing null
+        for c in raw[:-1].split('\0:')[1:]:
+            self.parse_change(c)
 
-        # Get a combined raw & patch diff from git diff-tree. The sections will
-        # be separated by '\0\0'.
-        [raw, patch] = check_output([
-            'git', 'diff-tree', '-r',
-            '--no-ext-diff', '--no-textconv', '--no-color', # No customization
-            '--raw', '-z',        # Add easy-to-parse \0-separated header
-            '--patch', '-U32767', # Include all patch context
-            '--full-index',       # Don't abbreviate the index sha1s
-            commit.commit_hash
-        ]).decode().split('\0\0', maxsplit=1)
+    @property
+    def added(self):
+        return sum(change.added for change in self.changes.values())
 
-        # Split the raw section on '\0:', the delimiter between raw changes
-        [junk, *raw_changes] = raw.split('\0:')
-        assert junk == commit.commit_hash, "unexpected junk leader!"
-        for change in raw_changes:
-            # '--raw -z' only uses '\0' to split paths, other sections are still
-            # space-separated.
-            [fields, a_path, *rest] = change.split('\0')
-            [a_mode, b_mode, a_hash, b_hash, kind] = fields.split(' ')
+    @property
+    def deleted(self):
+        return sum(change.deleted for change in self.changes.values())
 
-            # Determine which paths we are working with.
-            b_path = a_path
-            if len(rest) == 1:
-                b_path = rest[0]
+    def change_for(self, path):
+        if path not in self.changes:
+            self.changes[path] = self.Change(path)
+        return self.changes[path]
 
-            if kind[0] == 'A':
-                a_path = None
-                phk = Change.TYPE_ADD
-            elif kind[0] == 'D':
-                b_path = None
-                phk = Change.TYPE_DELETE
-            elif kind[0] == 'M':
-                phk = 0
+    def parse_change(self, raw):
+        """Parse a single raw change into a Change object"""
+        # `--raw -z` only uses '\0' to split paths, other sections are still
+        # space-separated.
+        [fields, *paths] = raw.split('\0')
+        [a_mode, b_mode, a_blob, b_blob, kind_l] = fields.split(' ')
+
+        # Figure out what paths and modes to use
+        if len(paths) == 2:
+            [a_path, b_path] = paths
+        else:
+            a_path = b_path = paths[0]
+        change = self.change_for(b_path)
+
+        # Extract the bodies of blobs to compare
+        a_body, b_body = b'', b''
+        if a_blob != NULL_SHA1:
+            a_body = check_output(['git', 'cat-file', 'blob', a_blob])
+        if b_blob != NULL_SHA1:
+            b_body = check_output(['git', 'cat-file', 'blob', b_blob])
+
+        # Detect if we're binary, and generate a unified diff
+        change.binary = b'\0' in a_body or b'\0' in b_body
+        if change.binary:
+            change.uploads = [
+                {'type': 'old', 'value': a_body, 'phid': None},
+                {'type': 'new', 'value': b_body, 'phid': None},
+            ]
+            change.hunks = []
+            change.file_type = self.FileType.BINARY
+        else:
+            change.uploads = []
+            # Generate the diff using difflib
+            [hdr, *corpus] = list(difflib.unified_diff(
+                a_body.decode().splitlines(),
+                b_body.decode().splitlines(),
+                n=99999999,
+            ))[2:]
+
+            # Match on the hunk line
+            m = re.match(r'@@ -(\d+),(\d+) \+(\d+),(\d+) @@', hdr, re.I)
+            change.hunks = [self.Hunk(
+                old_off=int(m.group(1)), old_len=int(m.group(2)),
+                new_off=int(m.group(3)), new_len=int(m.group(4)),
+                added=sum(1 for l in corpus if l[0] == '+'),
+                deleted=sum(1 for l in corpus if l[0] == '-'),
+                corpus='\n'.join(corpus),
+            )]
+            change.file_type = self.FileType.TEXT
+
+        # Determine the correct kind from the letter
+        if kind_l[0] == 'A':
+            change.kind = self.Kind.ADD
+            change.new_mode = b_mode
+
+        elif kind_l[0] == 'D':
+            change.kind = self.Kind.DELETE
+            change.old_mode = a_mode
+
+        elif kind_l[0] == 'M':
+            change.kind = self.Kind.CHANGE
+            change.old_mode = a_mode
+            change.new_mode = b_mode
+
+        elif kind_l[0] == 'R':
+            change.kind = self.Kind.MOVE_HERE
+            change.old_mode = a_mode
+            change.new_mode = b_mode
+
+            change.old_path = a_path
+            old = self.change_for(change.old_path)
+            if old.kind in [self.Kind.MOVE_AWAY, self.Kind.COPY_AWAY]:
+                old.kind = self.Kind.MULTICOPY
+            elif old.kind != self.Kind.MULTICOPY:
+                old.kind = self.Kind.MOVE_AWAY
+            old.away_paths.append(change.cur_path)
+
+        elif kind_l[0] == 'C':
+            change.kind = self.Kind.COPY_HERE
+            change.old_mode = a_mode
+            change.new_mode = b_mode
+
+            change.old_path = a_path
+            old = self.change_for(change.old_path)
+            if old.kind == self.Kind.MOVE_AWAY:
+                old.kind = self.Kind.MULTICOPY
             else:
-                raise UserError(f"Unhandled change type {kind}")
+                old.kind = self.Kind.COPY_AWAY
+            old.away_paths.append(change.cur_path)
 
-            # Create the change for this raw change.
-            change = Change(a_mode, b_mode, a_hash, b_hash, phk, a_path, b_path)
+        else:
+            raise f"unsupported change type {kind_l[0]}"
 
-            # Add the change to the list in question.
-            self.changes.append(change)
-            hash_to_changes[f"{a_hash}..{b_hash}"] = change
+        return change
 
-        # Walk through lines in the patch. Reading an 'index' line will switch
-        # to a new diff entry.
-        active_change = None
-        active_hunk = None
-        a_hunk_remaining = 0
-        b_hunk_remaining = 0
-        for line in patch.splitlines():
-            # Check for entering a new entry's header
-            indexmatch = re.match(r'index ([a-f0-9]{40}..[a-f0-9]{40})', line, re.I)
-            if indexmatch:
-                active_change = hash_to_changes[indexmatch.group(1)]
-                continue
-            elif active_change is None:
-                continue
+    def do_uploads(self, style, conduit):
+        for change in self.change.values():
+            for upload in change.uploads:
+                print(f"{style.yellow}{style.bold}Uploading Binary{style.reset}",
+                      f"{change.cur_path}")
+                data_base64 = base64.standard_b64encode(upload['value'])
+                upload['phid'] = conduit.do('file.upload',
+                                            data_base64=data_base64.decode())
+                print(f"    File PHID: {upload['phid']}")
 
-            # Detect binary diffs
-            if line.startswith('Binary files'): # XXX(nika): more robust?
-                assert len(active_change.hunks) == 0, "binary files have no hunks"
-                active_change.binary = True
-            if active_change.binary:
-                continue
-
-            # Detect hunks
-            hunkmatch = re.match(r'@@ -(\d+),(\d+) \+(\d+),(\d+) @@', line, re.I)
-            if hunkmatch:
-                active_hunk = Hunk(int(hunkmatch.group(1)),
-                                   int(hunkmatch.group(2)),
-                                   int(hunkmatch.group(3)),
-                                   int(hunkmatch.group(4)))
-                active_change.hunks.append(active_hunk)
-
-                # Keep track of how many lines are remaining for each hunk.
-                a_hunk_remaining = active_hunk.a_length
-                b_hunk_remaining = active_hunk.b_length
-                continue
-            elif active_hunk is None:
-                continue
-
-            # Add additions, removals, and context to the current hunk.
-            if line[0] == '+':
-                assert b_hunk_remaining > 0
-                active_change.added += 1
-                b_hunk_remaining -= 1
-                active_hunk.corpus.append(line)
-
-            if line[0] == '-':
-                assert a_hunk_remaining > 0
-                active_change.removed += 1
-                a_hunk_remaining -= 1
-                active_hunk.corpus.append(line)
-
-            if line[0] == ' ':
-                a_hunk_remaining -= 1
-                b_hunk_remaining -= 1
-                active_hunk.corpus.append(line)
-
-            # If we've seen all of the lines for the current hunk, end it.
-            if a_hunk_remaining == 0 and b_hunk_remaining == 0:
-                active_hunk = None
-
-        self.added = sum(c.added for c in self.changes)
-        self.removed = sum(c.removed for c in self.changes)
-
-    def to_conduit(self, conduit):
-        changes = [ch.to_conduit(conduit) for ch in self.changes]
+    def do_publish(self, style, conduit):
+        print(f"{style.yellow}{style.bold}Publishing Patch{style.reset}",
+              f"{self.commit.summary}")
+        changes = [change.to_conduit(self.commit)
+                   for change in self.changes.values()]
         diff = conduit.do('differential.creatediff',
                           changes=changes,
                           sourceMachine=conduit.hostname,
@@ -317,9 +338,10 @@ class Diff:
                           sourcePath=str(conduit.top),
                           # XXX(nika): This seems kinda irrelevant?
                           branch='HEAD')
+        print(f"    Diff URI: {diff['uri']}")
 
-        # Add information about local commits to the patch. This info is needed
-        # by lando.
+        # Add information about our local commit to the patch. This info is
+        # needed by lando.
         conduit.do('differential.setdiffproperty',
                    diff_id=diff['diffid'],
                    name='local:commits',
@@ -328,9 +350,14 @@ class Diff:
                            'author': self.commit.author_name,
                            'authorEmail': self.commit.author_email,
                            'time': int(self.commit.unix_date),
+                           'summary': self.commit.summary,
+                           'message': self.commit.raw_body,
+                           'commit': self.commit.hg_hash,
+                           'tree': self.commit.tree_hash,
+                           'parents': [self.commit.parent().hg_hash],
                        }
                    }))
-        return diff
+        return diff['phid']
 
 
 class Cached:
@@ -364,7 +391,7 @@ class Revision(Cached):
         if self._info is None:
             self._info = conduit.search_one('differential.revision', {
                 'ids': [self.revid]
-            }, attachments={ 'reviewers': True })
+            }, attachments={'reviewers': True})
         return self._info
 
     def url(self, conduit):
@@ -482,7 +509,7 @@ class Commit(Cached):
         def rev_replace(match):
             self.revision = Revision(match.group(2))
             return ""
-        self._summary = re.sub(
+        self.summary = re.sub(
             r'^Differential\s+Revision:\s*(.*/)?D([0-9]+)$',
             rev_replace, self.body, count=1, flags=re.I | re.M
         ).strip()
@@ -519,20 +546,11 @@ class Commit(Cached):
             'value': value,
         })
 
-    def summary(self, parent, pending_deps=False):
-        summary = self._summary
-
-        # If we have a valid parent revision, we can declare a dependency on it.
-        # If we're allowed to have pending dependencies (pending_deps is true),
-        # then we can declare a dependency on '<pending>'. Otherwise, we don't
-        # depend on anything.
-        if parent is not None:
-            if parent.revision:
-                summary += f"\n\nDepends on D{parent.revision.revid}"
-            elif pending_deps:
-                summary += f"\n\nDepends on D<pending>"
-
-        return summary.strip()
+    def new_summary(self, parent):
+        if parent is None:
+            return self.summary
+        revid = parent.revision.revid if parent.revision else '<pending>'
+        return f"{self.summary}\n\nDepends on D{revid}".strip()
 
     def recommit(self, parent, message):
         message = message.strip()  # Make sure to clean up trailing whitespace
@@ -684,32 +702,17 @@ def process_args(args):
     ensure_hg_hashes(push)
 
     # Define a helper for printing styled & labeled information to stdout.
-    def label(label, *rest, warn=False):
-        color = style.bold + (style.red if warn else style.cyan)
-        body = ' '.join(str(s) for s in rest)
-        if '\n' in body:
-            indent = '\n    '
-            body = body.replace('\n', indent)
-        else:
-            indent = ' ' * (14 - len(label))
-        print(f"  {color}{label}{style.reset}{indent}{body}")
+    def label(label, *rest):
+        body = ' '.join(str(s) for s in rest).replace('\n', '\n    ')
+        print(f"  {style.bold_cyan}{label}{style.reset}\n    {body}")
 
     # Validate that everything exists, and show computed info
-    for commit in push:
+    for idx, commit in enumerate(push):
         print(f"{style.yellow}{commit.abbrev}{style.reset} {commit.subject}")
 
         # Produce an error if no bug # was specified
         if commit.bug is None:
             raise UserError(f"no bug # specified")
-
-        # Determine which commit we're going to depend on, respecting
-        # --no-extern-deps.
-        dep_parent = commit.parent()
-        if args.no_extern_deps and dep_parent is start:
-            dep_parent = None
-        elif not (dep_parent.is_public or dep_parent is not start):
-            print(f"{style.red}{style.bold}warning: parent not public",
-                  f"(no revid, not hg){style.reset}", file=sys.stderr)
 
         # Determine which revision we're working with
         if commit.revision is None:
@@ -719,9 +722,6 @@ def process_args(args):
             revinfo = commit.revision.info(conduit)
             label('Revision', commit.revision.url(conduit))
         revfields = revinfo.get('fields', {})
-
-        # Log computed mercurial hashes.
-        label('Mercurial', f"{commit.hg_hash}")
 
         # Specify which repository we're working with
         oldrepo = revfields.get('repositoryPHID')
@@ -733,10 +733,15 @@ def process_args(args):
 
         # Log computed information about the patch to be pushed
         diff = commit.get_diff()
-        label('Changes',
-              f"{style.bold}{len(diff.changes)} files{style.reset}, "
-              f"{style.green}+{diff.added}{style.reset}, "
-              f"{style.red}-{diff.removed}{style.reset}")
+        summary = ''
+        longest = max(len(name) for name in diff.changes)
+        for path, change in diff.changes.items():
+            summary += f"{path:<{longest}} "
+            summary += f"{style.bold}+{change.added:<3} -{change.deleted:<3}{style.reset}\n"
+        summary += style.bold
+        summary += f"{len(diff.changes)} files (+{diff.added}, -{diff.deleted})"
+        summary += style.reset
+        label('Changes', summary)
 
         # Title Updates
         oldtitle = revfields.get('title')
@@ -746,7 +751,7 @@ def process_args(args):
 
         # Summary Generation
         oldsummary = revfields.get('summary')
-        summary = commit.summary(dep_parent, pending_deps=dep_parent is not start)
+        summary = commit.new_summary(commit.parent() if idx > 0 else None)
         if oldsummary != summary:
             commit.add_transaction('summary', summary)
             label('Set Summary', summary)
@@ -791,24 +796,26 @@ def process_args(args):
             raise UserError('user aborted')
         print()
 
+    # Perform all uploads, and then publish all patches.
+    for commit in push:
+        commit.get_diff().do_uploads(style, conduit)
+    for commit in push:
+        phid = commit.get_diff().do_publish(style, conduit)
+        commit.add_transaction('update', phid)
+
     # Perform the commit rewriting
     parent = start
-    for commit in push:
-        print(f"{style.yellow}{commit.abbrev}{style.reset} {commit.subject}")
+    for idx, commit in enumerate(push):
+        print(f"{style.yellow}{style.bold}Requesting Review{style.reset}",
+              f"{commit.summary}")
 
-        # Update transactions to reflect parent pushed revIDs, unless we should
-        # ignore our |start| parent due to --no-extern-deps
-        if not (args.no_extern_deps and parent is start):
-            for txn in commit.transactions:
-                if txn['type'] == 'summary':
-                    txn['value'] = commit.summary(parent)
-
-        diff = commit.get_diff().to_conduit(conduit)
-        label('Diff URI', diff['uri'])
-        commit.add_transaction('update', diff['phid'])
+        # Update transactions to reflect parent pushed revIDs
+        for txn in commit.transactions:
+            if txn['type'] == 'summary':
+                txn['value'] = commit.new_summary(parent if idx > 0 else None)
 
         # Send the revision edit request.
-        params = { 'transactions': commit.transactions }
+        params = {'transactions': commit.transactions}
         if commit.revision is not None:
             params['objectIdentifier'] = commit.revision.info(conduit)['phid']
         editrv = conduit.do('differential.revision.edit', **params)
@@ -818,7 +825,7 @@ def process_args(args):
             revurl = Revision(editrv['object']['id']).url(conduit)
         else:
             revurl = commit.revision.url(conduit)
-        label('Revision', revurl)
+        print(f"    Revision URI: {revurl}")
 
         # Perform a rewrite of the commit, and move to the next
         commitmsg = commit.raw_body.strip()

--- a/phlay
+++ b/phlay
@@ -389,17 +389,28 @@ class Bug(Cached):
         return self._info
 
 
-class User(Cached):
+class Reviewer(Cached):
     _info = None
 
-    def init(self, username):
-        self.username = username
+    def init(self, tag):
+        self.tag = tag
 
     def info(self, conduit):
         if self._info is None:
-            self._info = conduit.search_one('user', {
-                'usernames': [self.username]
-            })
+            try:
+                # First, we try to locate a user with the reviewer's name.
+                self._info = conduit.search_one('user', {
+                    'usernames': [self.tag]
+                })
+            except UserError:
+                try:
+                    # Then we locate a project based on its slug.
+                    self._info = conduit.search_one('project', {
+                        'slugs': [self.tag]
+                    })
+                except UserError:
+                    raise UserError(f"no such reviewer: {self.tag}")
+
         return self._info
 
 
@@ -464,7 +475,7 @@ class Commit(Cached):
         self.reviewers = []
         for rmatch in re.finditer(r'r((?:[?=,][^,\s]+)+)', self.subject, re.I):
             for name in re.split(r'[?=,]', rmatch.group(1))[1:]:
-                self.reviewers.append(User(name))
+                self.reviewers.append(Reviewer(name))
 
         # Parse the revision out of body, and strip to store in summary.
         self.revision = None
@@ -743,12 +754,17 @@ def process_args(args):
                 .get('reviewers', {}).get('reviewers', [])
         ]
         for reviewer in commit.reviewers:
-            userinfo = reviewer.info(conduit)
-            if userinfo['phid'] not in rev_phids:
-                to_add.append(userinfo['phid'])
-                label('Add Reviewer',
-                      userinfo['fields']['realName'],
-                      f"[:{userinfo['fields']['username']}]")
+            reviewerinfo = reviewer.info(conduit)
+            if reviewerinfo['phid'] not in rev_phids:
+                to_add.append(reviewerinfo['phid'])
+                if reviewerinfo['type'] == 'USER':
+                    label('Add Reviewer',
+                          reviewerinfo['fields']['realName'],
+                          f"[:{reviewerinfo['fields']['username']}]")
+                elif reviewerinfo['type'] == 'PROJ':
+                    label('Add Reviewer',
+                          reviewerinfo['fields']['name'],
+                          f"[#{reviewer.tag}]")
         if len(to_add) > 0:
             commit.add_transaction('reviewers.add', to_add)
 

--- a/phlay
+++ b/phlay
@@ -519,18 +519,18 @@ class Commit(Cached):
             'value': value,
         })
 
-    def summary(self, parent=None, pending_deps=False):
+    def summary(self, parent, pending_deps=False):
         summary = self._summary
-        parent = parent or self.parent()
 
         # If we have a valid parent revision, we can declare a dependency on it.
         # If we're allowed to have pending dependencies (pending_deps is true),
         # then we can declare a dependency on '<pending>'. Otherwise, we don't
         # depend on anything.
-        if parent.revision:
-            summary += f"\n\nDepends on D{parent.revision.revid}"
-        elif pending_deps:
-            summary += f"\n\nDepends on D<pending>"
+        if parent is not None:
+            if parent.revision:
+                summary += f"\n\nDepends on D{parent.revision.revid}"
+            elif pending_deps:
+                summary += f"\n\nDepends on D<pending>"
 
         return summary.strip()
 
@@ -702,8 +702,12 @@ def process_args(args):
         if commit.bug is None:
             raise UserError(f"no bug # specified")
 
-        # Check if we are missing a parent revision to depend on.
-        if not (commit.parent().is_public or commit.parent() in push):
+        # Determine which commit we're going to depend on, respecting
+        # --no-extern-deps.
+        dep_parent = commit.parent()
+        if args.no_extern_deps and dep_parent is start:
+            dep_parent = None
+        elif not (dep_parent.is_public or dep_parent is not start):
             print(f"{style.red}{style.bold}warning: parent not public",
                   f"(no revid, not hg){style.reset}", file=sys.stderr)
 
@@ -742,7 +746,7 @@ def process_args(args):
 
         # Summary Generation
         oldsummary = revfields.get('summary')
-        summary = commit.summary(pending_deps=commit.parent() in push)
+        summary = commit.summary(dep_parent, pending_deps=dep_parent is not start)
         if oldsummary != summary:
             commit.add_transaction('summary', summary)
             label('Set Summary', summary)
@@ -792,10 +796,12 @@ def process_args(args):
     for commit in push:
         print(f"{style.yellow}{commit.abbrev}{style.reset} {commit.subject}")
 
-        # Update transactions to reflect parent pushed revIDs
-        for txn in commit.transactions:
-            if txn['type'] == 'summary':
-                txn['value'] = commit.summary(parent=parent)
+        # Update transactions to reflect parent pushed revIDs, unless we should
+        # ignore our |start| parent due to --no-extern-deps
+        if not (args.no_extern_deps and parent is start):
+            for txn in commit.transactions:
+                if txn['type'] == 'summary':
+                    txn['value'] = commit.summary(parent)
 
         diff = commit.get_diff().to_conduit(conduit)
         label('Diff URI', diff['uri'])
@@ -846,6 +852,8 @@ def main():
     parser.add_argument('--color', default='auto',
                         choices=['always', 'never', 'auto'],
                         help='control output colorization')
+    parser.add_argument('--no-extern-deps', action='store_true',
+                        help='don\'t depend on revisions outside of push')
     parser.add_argument('revspec', nargs='?', default='HEAD',
                         help='commit range to phlay onto differential')
     args = parser.parse_args()

--- a/phlay
+++ b/phlay
@@ -23,8 +23,11 @@ NULL_SHA1 = '0' * 40
 
 class Style:
     """ANSI color helper"""
-    COLORS = 'black blue cyan green magenta red white yellow'.split()
-    SUGAR = dict(reset='sgr0', italic='sitm')
+    class Wrap(str):
+        def __call__(self, s):
+            if self == '':
+                return str(s)
+            return self + str(s) + curses.tparm(curses.tigetstr('sgr0')).decode()
 
     def __init__(self, color, stream=sys.stdout):
         self.styled = color == 'always' or (color == 'auto' and stream.isatty())
@@ -36,12 +39,11 @@ class Style:
         if not self.styled:
             return ''
         if '_' in name:
-            return ''.join(getattr(self, n) for n in name.split('_'))
-        name = self.SUGAR.get(name, name)
-        if name in self.COLORS:
-            num = getattr(curses, 'COLOR_' + name.upper())
-            return curses.tparm(self._setf, num).decode('latin1')
-        return curses.tparm(curses.tigetstr(name)).decode('latin1')
+            return self.Wrap(''.join(getattr(self, n) for n in name.split('_')))
+        call = [curses.tigetstr(name)]
+        if name in 'black blue cyan green magenta red white yellow'.split():
+            call = [self._setf, getattr(curses, 'COLOR_' + name.upper())]
+        return self.Wrap(curses.tparm(*call).decode())
 
 
 class UserError(Exception):
@@ -109,8 +111,6 @@ class Conduit:
 
 
 class Diff:
-    """simple diff parser"""
-
     Hunk = namedtuple('Hunk', ['old_off', 'old_len', 'new_off', 'new_len',
                                'added', 'deleted', 'corpus'])
 
@@ -321,8 +321,7 @@ class Diff:
                 print(f"    File PHID: {upload['phid']}")
 
     def do_publish(self, style, conduit):
-        print(f"{style.yellow}{style.bold}Publishing Patch{style.reset}",
-              f"{self.commit.summary}")
+        print(style.bold_yellow('Publishing Patch'), f"{self.commit.summary}")
         changes = [change.to_conduit(self.commit)
                    for change in self.changes.values()]
         diff = conduit.do('differential.creatediff',
@@ -698,17 +697,19 @@ def process_args(args):
     # Stash the current sha1 for |ref|
     initial_ref = Commit(ref)
 
+    print(style.bold_yellow("Calculating Hg Changesets"))
     # Ensure we have a mercurial hash for each commit we want to push.
     ensure_hg_hashes(push)
 
     # Define a helper for printing styled & labeled information to stdout.
     def label(label, *rest):
-        body = ' '.join(str(s) for s in rest).replace('\n', '\n    ')
-        print(f"  {style.bold_cyan}{label}{style.reset}\n    {body}")
+        print('  ' + style.bold_cyan(label))
+        print('    ' + ' '.join(str(s) for s in rest).replace('\n', '\n    '))
 
     # Validate that everything exists, and show computed info
     for idx, commit in enumerate(push):
-        print(f"{style.yellow}{commit.abbrev}{style.reset} {commit.subject}")
+        print()
+        print(f"{style.yellow(commit.abbrev)} {commit.subject}")
 
         # Produce an error if no bug # was specified
         if commit.bug is None:
@@ -737,10 +738,9 @@ def process_args(args):
         longest = max(len(name) for name in diff.changes)
         for path, change in diff.changes.items():
             summary += f"{path:<{longest}} "
-            summary += f"{style.bold}+{change.added:<3} -{change.deleted:<3}{style.reset}\n"
-        summary += style.bold
-        summary += f"{len(diff.changes)} files (+{diff.added}, -{diff.deleted})"
-        summary += style.reset
+            summary += style.bold(f"+{change.added:<3} -{change.deleted:<3}\n")
+        summary += style.bold(f"{len(diff.changes)} files")
+        summary += f" (+{style.green(diff.added)}, -{style.red(diff.deleted)})"
         label('Changes', summary)
 
         # Title Updates
@@ -761,10 +761,8 @@ def process_args(args):
         oldbugno = revfields.get('bugzilla.bug-id')
         if oldbugno != str(commit.bug.bugno):
             commit.add_transaction('bugzilla.bug-id', str(commit.bug.bugno))
-            label('Set Bug',
-                  f"Bug {commit.bug.bugno}",
-                  f"{style.bold}[{buginfo['status']}]{style.reset}",
-                  f"{buginfo['summary']}")
+            label('Set Bug', f"Bug {commit.bug.bugno}",
+                  style.bold(f"[{buginfo['status']}]"), f"{buginfo['summary']}")
 
         # Add any reviewers not in the original commit
         to_add = []
@@ -788,13 +786,11 @@ def process_args(args):
         if len(to_add) > 0:
             commit.add_transaction('reviewers.add', to_add)
 
-        print()
-
     # Request user confirmation of printed information.
     if not args.assume_yes:
-        if input(f"{style.bold}Proceed?{style.reset} (Y/n) ").lower() != 'y':
+        if input(style.bold('\nProceed? (Y/n) ')).lower() != 'y':
             raise UserError('user aborted')
-        print()
+    print()
 
     # Perform all uploads, and then publish all patches.
     for commit in push:
@@ -806,8 +802,7 @@ def process_args(args):
     # Perform the commit rewriting
     parent = start
     for idx, commit in enumerate(push):
-        print(f"{style.yellow}{style.bold}Requesting Review{style.reset}",
-              f"{commit.summary}")
+        print(style.bold_yellow(f"Requesting Review"), f"{commit.summary}")
 
         # Update transactions to reflect parent pushed revIDs
         for txn in commit.transactions:
@@ -839,10 +834,9 @@ def process_args(args):
 
     # Rewrite 'ref'
     if initial_ref != parent:
-        print(f"{style.bold}Updating {style.yellow}{ref}{style.reset}")
-        label('Old Value', initial_ref.commit_hash)
-        label('New Value', parent.commit_hash)
-        check_output([
+        print(style.bold_yellow(f"Updating {ref}"))
+        print(f"  {initial_ref.abbrev} => {parent.abbrev}")
+        check_call([
             'git', 'update-ref', '-m', 'phlay: rewrite',
             ref, parent.commit_hash, initial_ref.commit_hash,
         ])
@@ -869,8 +863,7 @@ def main():
         process_args(args)
     except UserError as e:
         style = Style(args.color, stream=sys.stderr)
-        print(f'{style.red}{style.bold}error{style.reset} {str(e)}',
-              file=sys.stderr)
+        print(style.bold_red('error'), e, file=sys.stderr)
         sys.exit(1)
 
 

--- a/phlay
+++ b/phlay
@@ -467,23 +467,6 @@ class Reviewer(Cached):
         return self._info
 
 
-class Blob(Cached):
-    _body = None
-
-    def init(self, hash):
-        self.hash = hash
-
-    def is_null(self):
-        return self.hash == NULL_SHA1
-
-    def body(self):
-        if self.is_null():
-            return None
-        if self._body is None:
-            self._body = check_output(['git', 'cat-file', 'blob', self.hash])
-        return self._body
-
-
 class Commit(Cached):
     # Fields pulled from 'git show'
     abbrev          = '%h'

--- a/phlay
+++ b/phlay
@@ -14,6 +14,9 @@ import base64
 import socket
 
 
+NULL_SHA1 = '0' * 40
+
+
 class Style:
     """ANSI color helper"""
     COLORS = 'black blue cyan green magenta red white yellow'.split()
@@ -70,7 +73,7 @@ class Conduit:
         self.user = self.do('user.whoami')
         self.hostname = socket.gethostname()
 
-    def do(self, name, **params):
+    def do(self, cmd_name, **params):
         # Add the token & write out parameters.
         params['__conduit__'] = { 'token': self.token }
         body = urlencode({
@@ -81,7 +84,7 @@ class Conduit:
 
         # Send the POST request
         conn = HTTPSConnection(self.url.netloc)
-        conn.request("POST", f'/api/{name}', body=body)
+        conn.request("POST", f'/api/{cmd_name}', body=body)
 
         # Read the response as JSON
         resp = json.load(conn.getresponse())
@@ -300,10 +303,9 @@ class Diff:
 
     def to_conduit(self, conduit):
         changes = [ch.to_conduit(conduit) for ch in self.changes]
-        return conduit.do('differential.creatediff',
+        diff = conduit.do('differential.creatediff',
                           changes=changes,
                           sourceMachine=conduit.hostname,
-                          # XXX(nika): say git if non-public commit?
                           sourceControlSystem='hg',
                           sourceControlPath='',
                           sourceControlBaseRevision=self.commit.parent().hg_hash,
@@ -316,6 +318,23 @@ class Diff:
                           sourcePath=str(conduit.top),
                           # XXX(nika): This seems kinda irrelevant?
                           branch='HEAD')
+
+        # Add information about local commits to the patch. This info is needed
+        # by lando.
+        conduit.do('differential.setdiffproperty',
+                   diff_id=diff['diffid'],
+                   name='local:commits',
+                   data=json.dumps({
+                       # XXX(nika): This is likely to be a git hash, but it's
+                       # our best effort. We can't force cinnabar to make a
+                       # mercurial hash right now.
+                       self.commit.hg_hash: {
+                           'author': self.commit.author_name,
+                           'authorEmail': self.commit.author_email,
+                           'time': int(self.commit.unix_date),
+                       }
+                   }))
+        return diff
 
 
 class Cached:
@@ -389,14 +408,13 @@ class User(Cached):
 
 
 class Blob(Cached):
-    null_hash = '0' * 40
     _body = None
 
     def init(self, hash):
         self.hash = hash
 
     def is_null(self):
-        return self.hash == self.null_hash
+        return self.hash == NULL_SHA1
 
     def body(self):
         if self.is_null():
@@ -415,6 +433,7 @@ class Commit(Cached):
     author_name     = '%an'
     author_email    = '%ae'
     author_date     = '%aD'
+    unix_date       = '%at'
     committer_name  = '%cn'
     committer_email = '%ce'
     committer_date  = '%cD'
@@ -424,6 +443,7 @@ class Commit(Cached):
 
     # The current diff cache for this commit
     _diff = None
+    real_hg_hash = True
 
     @classmethod
     def key(cls, rev):
@@ -464,13 +484,20 @@ class Commit(Cached):
             rev_replace, self.body, count=1, flags=re.I | re.M
         ).strip()
 
-        # Check if this commit has a corresponding hg revision
+        # Check if this commit has a corresponding hg revision. Fall back to the
+        # git revision if we can't find a mercurial one.
+        #
+        # XXX(nika): It would be nice to be able to force the creation of
+        # mercurial sha1s for some commits. Perhaps hg bundle parsing?
         try:
             self.hg_hash = check_output(['git', 'cinnabar', 'git2hg',
-                                         self.commit_hash]).decode()
+                                         self.commit_hash]).decode().strip()
         except CalledProcessError:
-            # XXX(nika): What should we do here?
-            self.hg_hash = '0' * 40
+            self.hg_hash = NULL_SHA1
+
+        if self.hg_hash == NULL_SHA1:
+            self.hg_hash = self.commit_hash
+            self.real_hg_hash = False
 
 
     def parent(self):
@@ -624,6 +651,13 @@ def process_args(args):
               f"{style.bold}{len(diff.changes)} files{style.reset}, "
               f"{style.green}+{diff.added}{style.reset}, "
               f"{style.red}-{diff.removed}{style.reset}")
+
+        # Log information about the mercirual base commit hash for first commit.
+        if commit.parent() not in push:
+            hg_base_warning = ''
+            if commit.parent().commit_hash == commit.parent().hg_hash:
+                hg_base_warning = f"{style.red}<git only>{style.reset} "
+            label('Hg Base', f"{hg_base_warning}{commit.parent().hg_hash}")
 
         # Title Updates
         oldtitle = revfields.get('title')

--- a/phlay
+++ b/phlay
@@ -58,8 +58,6 @@ class Conduit:
                         .decode().strip())
         with open(self.top / '.arcconfig') as f:
             arcconfig = json.load(f)
-        with open(Path(arcrc_path).expanduser()) as f:
-            arcrc = json.load(f)
 
         # Load the URL from the local arcconfig
         self.url = urlparse(arcconfig['phabricator.uri'])
@@ -67,19 +65,38 @@ class Conduit:
             raise UserError('Only HTTPS scheme phabricator.uri are supported')
 
         # Find our authentication token
+        arcrc_path = Path(arcrc_path).expanduser()
+        arcrc = {}
         try:
+            with open(arcrc_path) as f:
+                arcrc = json.load(f)
+
             self.token = next(data['token'] for url, data in arcrc['hosts'].items()
                               if urlparse(url).netloc == self.url.netloc)
-        except:
-            raise UserError(f'No token for host {self.url.netloc}')
+        except IOError, StopIteration:
+            self.token = input(f"""\
+LOGIN TO PHABRICATOR
+
+Open this page in your browser, and login if necessary:
+https://{self.url.netloc}/conduit/login
+
+API Token from that page: """).strip()
+
+            # Double-check the token works
+            self.do('user.whoami')
+
+            # Update our arcrc
+            api_uri = f"https://{self.url.netloc}/api/"
+            arcrc['hosts'] = arcrc.get('hosts', {})
+            arcrc['hosts'][api_uri] = arcrc['hosts'].get(api_uri, {})
+            arcrc['hosts'][api_uri]['token'] = self.token
+            with open(arcrc_path, 'w') as f:
+                json.dump(arcrc, f, indent=2)
 
         # Connect to Conduit to determine our repository's PHID
-        self.callsign = arcconfig['repository.callsign']
         self.repository = self.search_one('diffusion.repository', {
             'callsigns': [arcconfig['repository.callsign']]
         })
-
-        self.user = self.do('user.whoami')
         self.hostname = socket.gethostname()
 
     def do(self, cmd_name, **params):
@@ -508,8 +525,9 @@ class Commit(Cached):
         self.bug = bugmatch and Bug(bugmatch.group(1))
 
         # Parse the reviewer list
+        reviewer_re = r'r((?:[?=,][^,\s]+)+)'
         self.reviewers = []
-        for rmatch in re.finditer(r'r((?:[?=,][^,\s]+)+)', self.subject, re.I):
+        for rmatch in re.finditer(reviewer_re, self.subject, re.I):
             for name in re.split(r'[?=,]', rmatch.group(1))[1:]:
                 self.reviewers.append(Reviewer(name))
 
@@ -522,6 +540,9 @@ class Commit(Cached):
             r'^Differential\s+Revision:\s*(.*/)?D([0-9]+)$',
             rev_replace, self.body, count=1, flags=re.I | re.M
         ).strip()
+
+        self.title = re.sub(reviewer_re, '', self.subject, flags=re.I) \
+                       .strip(' ,.;')
 
         # Check if this commit has a corresponding mercurial hash already
         # computed and cached. If we don't, and we need it, we will compute it
@@ -655,7 +676,10 @@ def get_revisions(args):
 
     # Determine which commits to reparent vs. push
     if '..' in args.revspec:
-        start, end = map(Commit, args.revspec.split('..', 1))
+        start, end = args.revspec.split('..', 1)
+        if len(end) == 0:
+            end = 'HEAD'
+        start, end = Commit(start), Commit(end)
     else:
         end = Commit(args.revspec)
         start = end.parent()
@@ -712,12 +736,7 @@ def process_args(args):
 
         # Determine which revision we're working with
         if commit.revision is None:
-            buginfo = commit.bug.info(conduit)
-            label('New Revision', f"""\
-{style.bold('Bug ' + str(commit.bug.bugno))} {buginfo['status']} {buginfo['resolution']}
-  {buginfo['summary']}
-  {style.bold('Assigned To')} {buginfo['assigned_to_detail']['real_name']}
-{style.bold('Repository')} {conduit.repository['fields']['name']}""")
+            label('New Revision', conduit.repository['fields']['name'])
 
             commit.add_transaction('repositoryPHID', conduit.repository['phid'])
             commit.add_transaction('bugzilla.bug-id', str(commit.bug.bugno))
@@ -733,21 +752,25 @@ def process_args(args):
                 raise UserError('mismatched bug # ' +
                                 revfields['bugzilla.bug-id'])
 
+        # Always write out basic bug info
+        buginfo = commit.bug.info(conduit)
+        label(f"Bug {commit.bug.bugno}", buginfo['summary'])
+
         # Log computed information about the patch to be pushed
         diff = commit.diff()
         summary = ''
         longest = max(len(name) for name in diff.changes)
         for path, change in diff.changes.items():
             summary += f"{path:<{longest}} "
-            summary += style.bold(f"+{change.added:<3} -{change.deleted:<3}\n")
+            summary += style.bold(f"+{change.added}, -{change.deleted}\n")
         summary += style.bold(f"{len(diff.changes)} files")
-        summary += f" (+{style.green(diff.added)}, -{style.red(diff.deleted)})"
+        summary += f" (+{diff.added}, -{diff.deleted})"
         label('Changes', summary)
 
         # Title Updates
-        if not commit.revision or revinfo['fields']['title'] != commit.subject:
-            commit.add_transaction('title', commit.subject)
-            label('Set Title', commit.subject)
+        if not commit.revision or revinfo['fields']['title'] != commit.title:
+            commit.add_transaction('title', commit.title)
+            label('Set Title', commit.title)
 
         # Summary Updates
         oldsummary = commit.revision and commit.revision.summary(conduit)
@@ -791,7 +814,7 @@ def process_args(args):
 
     # Request user confirmation of printed information.
     if not args.assume_yes:
-        if input(style.bold('\nProceed? (Y/n) ')).lower() != 'y':
+        if input(style.bold('\nProceed? (y/N) ')).lower() != 'y':
             raise UserError('user aborted')
     print()
 

--- a/phlay
+++ b/phlay
@@ -496,6 +496,13 @@ class Commit(Cached):
         if self.hg_hash == NULL_SHA1:
             self.hg_hash = None
 
+        # We can /guess/ whether or not a commit is "public" (pushed to inbound)
+        # based on whether or not it has a cached hg_hash. non-"public" commits
+        # will have a null hg_hash, which is filled in during ensure_hg_hashes.
+        #
+        # Commits with revision IDs are also public.
+        self.is_public = self.hg_hash is not None or self.revision is not None
+
     def parent(self):
         if len(self.parent_hashes) == 1:
             return Commit(self.parent_hashes[0])
@@ -512,20 +519,19 @@ class Commit(Cached):
             'value': value,
         })
 
-    def is_part_one(self):
-        return self.parent() and self.bug != self.parent().bug
-
     def summary(self, parent=None, pending_deps=False):
         summary = self._summary
-        if not self.is_part_one():
-            parent = parent or self.parent()
-            if parent.revision:
-                revid = parent.revision.revid
-            elif pending_deps:
-                revid = "<pending>"
-            else:
-                raise UserError(f"no revision for {parent.abbrev}")
-            summary += f"\n\nDepends on D{revid}"
+        parent = parent or self.parent()
+
+        # If we have a valid parent revision, we can declare a dependency on it.
+        # If we're allowed to have pending dependencies (pending_deps is true),
+        # then we can declare a dependency on '<pending>'. Otherwise, we don't
+        # depend on anything.
+        if parent.revision:
+            summary += f"\n\nDepends on D{parent.revision.revid}"
+        elif pending_deps:
+            summary += f"\n\nDepends on D<pending>"
+
         return summary.strip()
 
     def recommit(self, parent, message):
@@ -695,6 +701,11 @@ def process_args(args):
         # Produce an error if no bug # was specified
         if commit.bug is None:
             raise UserError(f"no bug # specified")
+
+        # Check if we are missing a parent revision to depend on.
+        if not (commit.parent().is_public or commit.parent() in push):
+            print(f"{style.red}{style.bold}warning: parent not public",
+                  f"(no revid, not hg){style.reset}", file=sys.stderr)
 
         # Determine which revision we're working with
         if commit.revision is None:

--- a/phlay
+++ b/phlay
@@ -73,7 +73,7 @@ class Conduit:
 
             self.token = next(data['token'] for url, data in arcrc['hosts'].items()
                               if urlparse(url).netloc == self.url.netloc)
-        except IOError, StopIteration:
+        except (IOError, StopIteration):
             self.token = input(f"""\
 LOGIN TO PHABRICATOR
 
@@ -329,7 +329,7 @@ class Diff:
         return change
 
     def do_uploads(self, style, conduit):
-        for change in self.change.values():
+        for change in self.changes.values():
             for upload in change.uploads:
                 print(f"{style.yellow}{style.bold}Uploading Binary{style.reset}",
                       f"{change.cur_path}")

--- a/phlay
+++ b/phlay
@@ -865,8 +865,6 @@ def main():
     parser.add_argument('--color', default='auto',
                         choices=['always', 'never', 'auto'],
                         help='control output colorization')
-    parser.add_argument('--no-extern-deps', action='store_true',
-                        help='don\'t depend on revisions outside of push')
     parser.add_argument('revspec', nargs='?', default='HEAD',
                         help='commit range to phlay onto differential')
     args = parser.parse_args()

--- a/phlay
+++ b/phlay
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 
-from http.client import HTTPSConnection
-from urllib.parse import urlencode, urlparse
-from subprocess import check_output, check_call, CalledProcessError
-from argparse import ArgumentParser
-from tempfile import TemporaryDirectory
-from pathlib import Path
 import sys
 import os
 import re
@@ -14,7 +8,14 @@ import curses
 import base64
 import socket
 import difflib
+
+from http.client import HTTPSConnection
+from urllib.parse import urlencode, urlparse
+from subprocess import check_output, check_call, CalledProcessError
+from argparse import ArgumentParser
+from tempfile import TemporaryDirectory
 from collections import namedtuple
+from pathlib import Path
 from enum import Enum
 
 
@@ -382,6 +383,7 @@ class Cached:
 
 class Revision(Cached):
     _info = None
+    DEP_SPEC = re.compile(r'Depends\s+On\s*D([0-9]+)', re.I)
 
     def init(self, revid):
         self.revid = int(revid)
@@ -392,6 +394,15 @@ class Revision(Cached):
                 'ids': [self.revid]
             }, attachments={'reviewers': True})
         return self._info
+
+    def summary(self, conduit):
+        return self.DEP_SPEC.sub(
+            '', self.info(conduit)['fields']['summary'], count=1
+        ).strip()
+
+    def depends_on(self, conduit):
+        dep = self.DEP_SPEC.match(self.info(conduit)['fields']['summary'])
+        return Revision(dep.group(1)) if dep else None
 
     def url(self, conduit):
         return f"https://{conduit.url.netloc}/D{self.revid}"
@@ -406,8 +417,7 @@ class Bug(Cached):
     def info(self, _conduit):
         if self._info is None:
             conn = HTTPSConnection('bugzilla.mozilla.org')
-            conn.request('GET',
-                f"/rest/bug/{self.bugno}?include_fields=summary,status")
+            conn.request('GET', f"/rest/bug/{self.bugno}")
             resp = json.load(conn.getresponse())
             if resp.get('error', False):
                 raise UserError(resp['message'])
@@ -519,22 +529,13 @@ class Commit(Cached):
         self.hg_hash = check_output([
             'git', 'cinnabar', 'git2hg', self.commit_hash
         ]).decode().strip()
-        if self.hg_hash == NULL_SHA1:
-            self.hg_hash = None
-
-        # We can /guess/ whether or not a commit is "public" (pushed to inbound)
-        # based on whether or not it has a cached hg_hash. non-"public" commits
-        # will have a null hg_hash, which is filled in during ensure_hg_hashes.
-        #
-        # Commits with revision IDs are also public.
-        self.is_public = self.hg_hash is not None or self.revision is not None
 
     def parent(self):
         if len(self.parent_hashes) == 1:
             return Commit(self.parent_hashes[0])
         return None
 
-    def get_diff(self):
+    def diff(self):
         if not self._diff:
             self._diff = Diff(self)
         return self._diff
@@ -544,12 +545,6 @@ class Commit(Cached):
             'type': type,
             'value': value,
         })
-
-    def new_summary(self, parent):
-        if parent is None:
-            return self.summary
-        revid = parent.revision.revid if parent.revision else '<pending>'
-        return f"{self.summary}\n\nDepends on D{revid}".strip()
 
     def recommit(self, parent, message):
         message = message.strip()  # Make sure to clean up trailing whitespace
@@ -586,7 +581,7 @@ def ensure_hg_hashes(commits):
     # which does.
     to_hg = []
     current = commits[0].parent()
-    while not (current and current.hg_hash):
+    while not (current and current.hg_hash != NULL_SHA1):
         if current is None:
             raise UserError(f'no direct mercurial ancestor!')
         to_hg.append(current)
@@ -641,7 +636,7 @@ def ensure_hg_hashes(commits):
 
     # Apply the computed hg_ptoc map to add mercurial hashes
     for commit in to_hg:
-        assert commit.parent().hg_hash is not None
+        assert commit.parent().hg_hash != NULL_SHA1
         commit.hg_hash = hg_ptoc[commit.parent().hg_hash]
 
 
@@ -717,23 +712,29 @@ def process_args(args):
 
         # Determine which revision we're working with
         if commit.revision is None:
-            revinfo = {}
-            label('Revision', '<<new>>')
+            buginfo = commit.bug.info(conduit)
+            label('New Revision', f"""\
+{style.bold('Bug ' + str(commit.bug.bugno))} {buginfo['status']} {buginfo['resolution']}
+  {buginfo['summary']}
+  {style.bold('Assigned To')} {buginfo['assigned_to_detail']['real_name']}
+{style.bold('Repository')} {conduit.repository['fields']['name']}""")
+
+            commit.add_transaction('repositoryPHID', conduit.repository['phid'])
+            commit.add_transaction('bugzilla.bug-id', str(commit.bug.bugno))
         else:
             revinfo = commit.revision.info(conduit)
-            label('Revision', commit.revision.url(conduit))
-        revfields = revinfo.get('fields', {})
+            revfields = revinfo['fields']
+            label('Update Revision', commit.revision.url(conduit))
 
-        # Specify which repository we're working with
-        oldrepo = revfields.get('repositoryPHID')
-        if not oldrepo:
-            commit.add_transaction('repositoryPHID', conduit.repository['phid'])
-            label('Repository', conduit.repository['fields']['name'])
-        elif oldrepo != conduit.repository['phid']:
-            raise UserError('specified revision for incorrect repository!')
+            if revfields['repositoryPHID'] != conduit.repository['phid']:
+                raise UserError('mismatched revision repository ' +
+                                revfields['repositoryPHID'])
+            if revfields['bugzilla.bug-id'] != str(commit.bug.bugno):
+                raise UserError('mismatched bug # ' +
+                                revfields['bugzilla.bug-id'])
 
         # Log computed information about the patch to be pushed
-        diff = commit.get_diff()
+        diff = commit.diff()
         summary = ''
         longest = max(len(name) for name in diff.changes)
         for path, change in diff.changes.items():
@@ -744,33 +745,35 @@ def process_args(args):
         label('Changes', summary)
 
         # Title Updates
-        oldtitle = revfields.get('title')
-        if oldtitle != commit.subject:
+        if not commit.revision or revinfo['fields']['title'] != commit.subject:
             commit.add_transaction('title', commit.subject)
             label('Set Title', commit.subject)
 
-        # Summary Generation
-        oldsummary = revfields.get('summary')
-        summary = commit.new_summary(commit.parent() if idx > 0 else None)
-        if oldsummary != summary:
-            commit.add_transaction('summary', summary)
-            label('Set Summary', summary)
+        # Summary Updates
+        oldsummary = commit.revision and commit.revision.summary(conduit)
+        if oldsummary != commit.summary:
+            commit.add_transaction('summary', commit.summary)
+            label('Set Summary', commit.summary)
 
-        # Update the Bug #
-        buginfo = commit.bug.info(conduit)
-        oldbugno = revfields.get('bugzilla.bug-id')
-        if oldbugno != str(commit.bug.bugno):
-            commit.add_transaction('bugzilla.bug-id', str(commit.bug.bugno))
-            label('Set Bug', f"Bug {commit.bug.bugno}",
-                  style.bold(f"[{buginfo['status']}]"), f"{buginfo['summary']}")
+        # Do some validation on dependencies
+        olddepends = commit.revision and commit.revision.depends_on(conduit)
+        if olddepends:
+            # Check for attempts to change the dependency graph
+            if idx == 0:
+                raise UserError(f"parent D{olddepends.id} not in push")
+            elif commit.parent.revision != olddepends:
+                raise UserError(f"phlay can't change parent D{olddepends.id}")
+        elif idx > 0 and oldsummary == commit.summary:
+            # Force a summary change if a dependency add is needed
+            commit.add_transaction('summary', commit.summary)
 
         # Add any reviewers not in the original commit
         to_add = []
-        rev_phids = [
-            reviewer['reviewerPHID']
-            for reviewer in revinfo.get('attachments', {})
-                .get('reviewers', {}).get('reviewers', [])
-        ]
+        rev_phids = []
+        if commit.revision:
+            reviewers = revinfo['attachments']['reviewers']['reviewers']
+            rev_phids = [reviewer['reviewerPHID'] for reviewer in reviewers]
+
         for reviewer in commit.reviewers:
             reviewerinfo = reviewer.info(conduit)
             if reviewerinfo['phid'] not in rev_phids:
@@ -794,9 +797,9 @@ def process_args(args):
 
     # Perform all uploads, and then publish all patches.
     for commit in push:
-        commit.get_diff().do_uploads(style, conduit)
+        commit.diff().do_uploads(style, conduit)
     for commit in push:
-        phid = commit.get_diff().do_publish(style, conduit)
+        phid = commit.diff().do_publish(style, conduit)
         commit.add_transaction('update', phid)
 
     # Perform the commit rewriting
@@ -804,10 +807,13 @@ def process_args(args):
     for idx, commit in enumerate(push):
         print(style.bold_yellow(f"Requesting Review"), f"{commit.summary}")
 
-        # Update transactions to reflect parent pushed revIDs
-        for txn in commit.transactions:
-            if txn['type'] == 'summary':
-                txn['value'] = commit.new_summary(parent if idx > 0 else None)
+        # Add a 'Depends on' entry to the transaction if needed
+        if idx > 0:
+            for txn in commit.transactions:
+                if txn['type'] == 'summary':
+                    txn['value'] += "\n\nDepends on " + parent.revision.revid
+                    txn['value'] = txn['value'].strip()
+                    break
 
         # Send the revision edit request.
         params = {'transactions': commit.transactions}

--- a/phlay
+++ b/phlay
@@ -2,8 +2,9 @@
 
 from http.client import HTTPSConnection
 from urllib.parse import urlencode, urlparse
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output, check_call, CalledProcessError
 from argparse import ArgumentParser
+from tempfile import TemporaryDirectory
 from pathlib import Path
 import sys
 import os
@@ -307,14 +308,12 @@ class Diff:
                           changes=changes,
                           sourceMachine=conduit.hostname,
                           sourceControlSystem='hg',
-                          sourceControlPath='',
+                          sourceControlPath='/',
                           sourceControlBaseRevision=self.commit.parent().hg_hash,
                           creationMethod='phlay',
                           lintStatus='none',
                           unitStatus='none',
                           repositoryPHID=conduit.repository['phid'],
-
-                          # XXX(nika): Why send this?
                           sourcePath=str(conduit.top),
                           # XXX(nika): This seems kinda irrelevant?
                           branch='HEAD')
@@ -325,9 +324,6 @@ class Diff:
                    diff_id=diff['diffid'],
                    name='local:commits',
                    data=json.dumps({
-                       # XXX(nika): This is likely to be a git hash, but it's
-                       # our best effort. We can't force cinnabar to make a
-                       # mercurial hash right now.
                        self.commit.hg_hash: {
                            'author': self.commit.author_name,
                            'authorEmail': self.commit.author_email,
@@ -441,10 +437,6 @@ class Commit(Cached):
     body            = '%b'
     raw_body        = '%B'
 
-    # The current diff cache for this commit
-    _diff = None
-    real_hg_hash = True
-
     @classmethod
     def key(cls, rev):
         if re.fullmatch(r'[a-f0-9]{40}', rev, re.I):
@@ -452,8 +444,8 @@ class Commit(Cached):
         return check_output(['git', 'rev-parse', '--verify', rev]).decode().strip()
 
     def init(self, rev):
-        # XXX(nika): Consider making this part lazy?
         self.transactions = []
+        self._diff = None
 
         # Read information from 'git show'
         FIELDS = { k: v for k, v in Commit.__dict__.items()
@@ -484,21 +476,14 @@ class Commit(Cached):
             rev_replace, self.body, count=1, flags=re.I | re.M
         ).strip()
 
-        # Check if this commit has a corresponding hg revision. Fall back to the
-        # git revision if we can't find a mercurial one.
-        #
-        # XXX(nika): It would be nice to be able to force the creation of
-        # mercurial sha1s for some commits. Perhaps hg bundle parsing?
-        try:
-            self.hg_hash = check_output(['git', 'cinnabar', 'git2hg',
-                                         self.commit_hash]).decode().strip()
-        except CalledProcessError:
-            self.hg_hash = NULL_SHA1
-
+        # Check if this commit has a corresponding mercurial hash already
+        # computed and cached. If we don't, and we need it, we will compute it
+        # later in ensure_hg_hashes.
+        self.hg_hash = check_output([
+            'git', 'cinnabar', 'git2hg', self.commit_hash
+        ]).decode().strip()
         if self.hg_hash == NULL_SHA1:
-            self.hg_hash = self.commit_hash
-            self.real_hg_hash = False
-
+            self.hg_hash = None
 
     def parent(self):
         if len(self.parent_hashes) == 1:
@@ -557,6 +542,75 @@ class Commit(Cached):
         return f'<commit {self.abbrev} {repr(self.subject)}>'
 
 
+def ensure_hg_hashes(commits):
+    """Ensures that the range of commits 'commits' all has valid mercurial
+    hashes. |commits| must be sorted, with the oldest commit at index |0|."""
+
+    # Determine the set of commits which we will make into mercurial commits.
+    # Cinnabar will complain if our base commit's parent doesn't have a
+    # precomputed mercurial hash, so we have to climb until we find a commit
+    # which does.
+    to_hg = []
+    current = commits[0].parent()
+    while not (current and current.hg_hash):
+        if current is None:
+            raise UserError(f'no direct mercurial ancestor!')
+        to_hg.append(current)
+        current = current.parent()
+    to_hg.reverse()
+    to_hg += commits
+
+    # Map from mercurial parent commits to child commits.
+    hg_ptoc = {}
+
+    # Get cinnabar to export a bundle with the specified commits. This will
+    # determine the mercurial hashes for those commits. We then parse the v1
+    # bundle format to extract relevant sha1 values.
+    with TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, 'bundle.hg')
+
+        # XXX(nika): This is probably the slowest part of phlay. Perhaps we could
+        # run it in parallel with the other network/io code (e.g. using asyncio)?
+        # We don't need the information until after you approve selected commits.
+        check_call(['git', 'cinnabar', 'bundle',
+                    '--version', '1', path,
+                    f"{current.commit_hash}..{to_hg[-1].commit_hash}"])
+
+        # The header of each chunk is 84 bytes long (4 bytes of length, 4x20
+        # bytes of sha1 hashes).
+        CHUNK_HEADER = 84
+
+        with open(path, 'rb') as f:
+            # Check the bundle type is an uncompressed v1 bundle.
+            assert f.read(6) == b'HG10UN', "bad bundle type"
+
+            while True:
+                # Read the size of the current section. A size too small to fit
+                # a header means we're done.
+                length = int.from_bytes(f.read(4), byteorder='big')
+                if length <= CHUNK_HEADER:
+                    break
+
+                # Read the header, containing 4x sha1 hashes, and skip the
+                # remaining data.
+                node = f.read(20).hex()
+                parent1 = f.read(20).hex()
+                parent2 = f.read(20).hex()
+                changeset = f.read(20).hex()
+                f.read(length - CHUNK_HEADER)
+
+                assert parent2 == NULL_SHA1, "Should have 1 parent"
+                assert changeset == node, "Changeset should match node"
+
+                # Stash the parent-to-child mapping
+                hg_ptoc[parent1] = node
+
+    # Apply the computed hg_ptoc map to add mercurial hashes
+    for commit in to_hg:
+        assert commit.parent().hg_hash is not None
+        commit.hg_hash = hg_ptoc[commit.parent().hg_hash]
+
+
 def get_revisions(args):
     # Check our 'ref' argument
     if args.ref != 'HEAD':
@@ -609,6 +663,9 @@ def process_args(args):
     # Stash the current sha1 for |ref|
     initial_ref = Commit(ref)
 
+    # Ensure we have a mercurial hash for each commit we want to push.
+    ensure_hg_hashes(push)
+
     # Define a helper for printing styled & labeled information to stdout.
     def label(label, *rest, warn=False):
         color = style.bold + (style.red if warn else style.cyan)
@@ -637,6 +694,9 @@ def process_args(args):
             label('Revision', commit.revision.url(conduit))
         revfields = revinfo.get('fields', {})
 
+        # Log computed mercurial hashes.
+        label('Mercurial', f"{commit.hg_hash}")
+
         # Specify which repository we're working with
         oldrepo = revfields.get('repositoryPHID')
         if not oldrepo:
@@ -651,13 +711,6 @@ def process_args(args):
               f"{style.bold}{len(diff.changes)} files{style.reset}, "
               f"{style.green}+{diff.added}{style.reset}, "
               f"{style.red}-{diff.removed}{style.reset}")
-
-        # Log information about the mercirual base commit hash for first commit.
-        if commit.parent() not in push:
-            hg_base_warning = ''
-            if commit.parent().commit_hash == commit.parent().hg_hash:
-                hg_base_warning = f"{style.red}<git only>{style.reset} "
-            label('Hg Base', f"{hg_base_warning}{commit.parent().hg_hash}")
 
         # Title Updates
         oldtitle = revfields.get('title')
@@ -698,7 +751,6 @@ def process_args(args):
                       f"[:{userinfo['fields']['username']}]")
         if len(to_add) > 0:
             commit.add_transaction('reviewers.add', to_add)
-
 
         print()
 

--- a/phlay
+++ b/phlay
@@ -100,7 +100,7 @@ class Conduit:
 
 
 class Hunk:
-    def __new__(self, a_offset, a_length, b_offset, b_length):
+    def __init__(self, a_offset, a_length, b_offset, b_length):
         self.a_offset = a_offset
         self.a_length = a_length
         self.b_offset = b_offset
@@ -123,13 +123,13 @@ class Change:
     TYPE_ADD        = 1
     TYPE_CHANGE     = 2
     TYPE_DELETE     = 3
+
+    # XXX(nika): Add support for moves/copies
     TYPE_MOVE_AWAY  = 4
     TYPE_COPY_AWAY  = 5
     TYPE_MOVE_HERE  = 6
     TYPE_COPY_HERE  = 7
     TYPE_MULTICOPY  = 8
-    TYPE_MESSAGE    = 9
-    TYPE_CHILD      = 10
 
     FILE_TEXT       = 1
     FILE_IMAGE      = 2
@@ -139,7 +139,7 @@ class Change:
     FILE_DELETED    = 6
     FILE_NORMAL     = 7
 
-    def __new__(self, a_mode, b_mode, a_sha, b_sha, kind, a_path, b_path):
+    def __init__(self, a_mode, b_mode, a_sha, b_sha, kind, a_path, b_path):
         self.a_mode = a_mode
         self.b_mode = b_mode
         self.a_blob = Blob(a_sha)
@@ -167,26 +167,18 @@ class Change:
                 # XXX(nika): Guess mime type?
             }
 
-        # XXX(nika): Support more change types?
-        changeType = 0
-        oldPath = self.a_path
-        if self.kind.startswith('A'):
-            changeType = self.TYPE_ADD
-            oldPath = None
-        elif self.kind.startswith('D'):
-            changeType = self.TYPE_DELETE
-        elif self.kind.startswith('R'):
-            changeType = self.TYPE_MOVE_HERE
+        old_props = { 'unix:filemode': self.a_mode } if self.a_path else {}
+        new_props = { 'unix:filemode': self.b_mode } if self.b_path else {}
 
         return {
             'metadata': metadata,
-            'oldProperties': { 'unix:filemode': self.a_mode },
-            'newProperties': { 'unix:filemode': self.b_mode },
-            'oldPath': oldPath,
+            'oldProperties': old_props,
+            'newProperties': new_props,
+            'oldPath': self.a_path,
             'currentPath': self.b_path,
             'addLines': self.added,
             'delLines': self.removed,
-            'type': changeType,
+            'type': self.kind,
             'fileType': self.FILE_BINARY if self.binary else self.FILE_TEXT,
             'hunks': [hunk.to_conduit(conduit) for hunk in self.hunks],
         }
@@ -196,7 +188,9 @@ class Diff:
     """simple diff parser"""
     def __init__(self, commit):
         self.commit = commit
-        self.changes = {}
+        self.changes = []
+
+        hash_to_changes = {}
 
         # Get a combined raw & patch diff from git diff-tree. The sections will
         # be separated by '\0\0'.
@@ -223,10 +217,23 @@ class Diff:
             if len(rest) == 1:
                 b_path = rest[0]
 
+            if kind[0] == 'A':
+                a_path = None
+                phk = Change.TYPE_ADD
+            elif kind[0] == 'D':
+                b_path = None
+                phk = Change.TYPE_DELETE
+            elif kind[0] == 'M':
+                phk = 0
+            else:
+                raise UserError(f"Unhandled change type {kind}")
+
             # Create the change for this raw change.
-            key = f"{a_hash}..{b_hash}"
-            self.changes[key] = \
-                Change(a_mode, b_mode, a_hash, b_hash, kind, a_path, b_path)
+            change = Change(a_mode, b_mode, a_hash, b_hash, phk, a_path, b_path)
+
+            # Add the change to the list in question.
+            self.changes.append(change)
+            hash_to_changes[f"{a_hash}..{b_hash}"] = change
 
         # Walk through lines in the patch. Reading an 'index' line will switch
         # to a new diff entry.
@@ -238,7 +245,7 @@ class Diff:
             # Check for entering a new entry's header
             indexmatch = re.match(r'index ([a-f0-9]{40}..[a-f0-9]{40})', line, re.I)
             if indexmatch:
-                active_change = self.changes[indexmatch.group(1)]
+                active_change = hash_to_changes[indexmatch.group(1)]
                 continue
             elif active_change is None:
                 continue
@@ -288,8 +295,11 @@ class Diff:
             if a_hunk_remaining == 0 and b_hunk_remaining == 0:
                 active_hunk = None
 
+        self.added = sum(c.added for c in self.changes)
+        self.removed = sum(c.removed for c in self.changes)
+
     def to_conduit(self, conduit):
-        changes = [ch.to_conduit(conduit) for ch in self.changes.values()]
+        changes = [ch.to_conduit(conduit) for ch in self.changes]
         return conduit.do('differential.creatediff',
                           changes=changes,
                           sourceMachine=conduit.hostname,
@@ -303,7 +313,7 @@ class Diff:
                           repositoryPHID=conduit.repository['phid'],
 
                           # XXX(nika): Why send this?
-                          sourcePath=conduit.top,
+                          sourcePath=str(conduit.top),
                           # XXX(nika): This seems kinda irrelevant?
                           branch='HEAD')
 
@@ -412,6 +422,9 @@ class Commit(Cached):
     body            = '%b'
     raw_body        = '%B'
 
+    # The current diff cache for this commit
+    _diff = None
+
     @classmethod
     def key(cls, rev):
         if re.fullmatch(r'[a-f0-9]{40}', rev, re.I):
@@ -454,9 +467,10 @@ class Commit(Cached):
         # Check if this commit has a corresponding hg revision
         try:
             self.hg_hash = check_output(['git', 'cinnabar', 'git2hg',
-                                         self.commit_hash])
+                                         self.commit_hash]).decode()
         except CalledProcessError:
-            self.hg_hash = '0' * 40 # XXX: uhh? do better?
+            # XXX(nika): What should we do here?
+            self.hg_hash = '0' * 40
 
 
     def parent(self):
@@ -465,18 +479,9 @@ class Commit(Cached):
         return None
 
     def get_diff(self):
-        return Diff(check_output([
-            'git', 'diff-tree',
-            '--no-ext-diff',
-            '--no-textconv',
-            '--submodule=short',
-            '--no-color',
-            '--src-prefix=a/',
-            '--dst-prefix=b/',
-            '--patch-with-raw',
-            '-U32767',
-            self.commit_hash
-        ]).decode())
+        if not self._diff:
+            self._diff = Diff(self)
+        return self._diff
 
     def add_transaction(self, type, value):
         self.transactions.append({
@@ -613,6 +618,13 @@ def process_args(args):
         elif oldrepo != conduit.repository['phid']:
             raise UserError('specified revision for incorrect repository!')
 
+        # Log computed information about the patch to be pushed
+        diff = commit.get_diff()
+        label('Changes',
+              f"{style.bold}{len(diff.changes)} files{style.reset}, "
+              f"{style.green}+{diff.added}{style.reset}, "
+              f"{style.red}-{diff.removed}{style.reset}")
+
         # Title Updates
         oldtitle = revfields.get('title')
         if oldtitle != commit.subject:
@@ -652,6 +664,7 @@ def process_args(args):
                       f"[:{userinfo['fields']['username']}]")
         if len(to_add) > 0:
             commit.add_transaction('reviewers.add', to_add)
+
 
         print()
 

--- a/phlay
+++ b/phlay
@@ -2,7 +2,7 @@
 
 from http.client import HTTPSConnection
 from urllib.parse import urlencode, urlparse
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 from argparse import ArgumentParser
 from pathlib import Path
 import sys
@@ -10,6 +10,8 @@ import os
 import re
 import json
 import curses
+import base64
+import socket
 
 
 class Style:
@@ -65,6 +67,9 @@ class Conduit:
             'callsigns': [arcconfig['repository.callsign']]
         })
 
+        self.user = self.do('user.whoami')
+        self.hostname = socket.gethostname()
+
     def do(self, name, **params):
         # Add the token & write out parameters.
         params['__conduit__'] = { 'token': self.token }
@@ -92,6 +97,215 @@ class Conduit:
         if len(resp['data']) != 1:
             raise UserError(f'cannot find {what} (constraints={constraints})')
         return resp['data'][0]
+
+
+class Hunk:
+    def __new__(self, a_offset, a_length, b_offset, b_length):
+        self.a_offset = a_offset
+        self.a_length = a_length
+        self.b_offset = b_offset
+        self.b_length = b_length
+        self.corpus = []
+
+    def to_conduit(self, _conduit):
+        return {
+            'oldOffset': self.a_offset,
+            'oldLength': self.a_length,
+            'newOffset': self.b_offset,
+            'newLength': self.b_length,
+            'corpus': '\n'.join(self.corpus),
+        }
+
+
+class Change:
+    """Individual file change as part of a changeset"""
+    # I just love magic numbers~!
+    TYPE_ADD        = 1
+    TYPE_CHANGE     = 2
+    TYPE_DELETE     = 3
+    TYPE_MOVE_AWAY  = 4
+    TYPE_COPY_AWAY  = 5
+    TYPE_MOVE_HERE  = 6
+    TYPE_COPY_HERE  = 7
+    TYPE_MULTICOPY  = 8
+    TYPE_MESSAGE    = 9
+    TYPE_CHILD      = 10
+
+    FILE_TEXT       = 1
+    FILE_IMAGE      = 2
+    FILE_BINARY     = 3
+    FILE_DIRECTORY  = 4
+    FILE_SYMLINK    = 5
+    FILE_DELETED    = 6
+    FILE_NORMAL     = 7
+
+    def __new__(self, a_mode, b_mode, a_sha, b_sha, kind, a_path, b_path):
+        self.a_mode = a_mode
+        self.b_mode = b_mode
+        self.a_blob = Blob(a_sha)
+        self.b_blob = Blob(b_sha)
+        self.kind = kind
+        self.a_path = a_path
+        self.b_path = b_path
+
+        # Information about diff state
+        self.hunks = []
+        self.added = 0
+        self.removed = 0
+        self.binary = False
+
+    def to_conduit(self, conduit):
+        # Upload binary blobs if necessary.
+        metadata = {}
+        if self.binary and self.b_blob.body() is not None:
+            data_base64 = base64.standard_b64encode(self.b_blob.body()).decode()
+            binary_phid = conduit.do('file.upload', data_base64=data_base64)
+            metadata = {
+                'old:file-size': len(self.a_blob.body()),
+                'new:file-size': len(self.b_blob.body()),
+                'new:binary-phid': binary_phid,
+                # XXX(nika): Guess mime type?
+            }
+
+        # XXX(nika): Support more change types?
+        changeType = 0
+        oldPath = self.a_path
+        if self.kind.startswith('A'):
+            changeType = self.TYPE_ADD
+            oldPath = None
+        elif self.kind.startswith('D'):
+            changeType = self.TYPE_DELETE
+        elif self.kind.startswith('R'):
+            changeType = self.TYPE_MOVE_HERE
+
+        return {
+            'metadata': metadata,
+            'oldProperties': { 'unix:filemode': self.a_mode },
+            'newProperties': { 'unix:filemode': self.b_mode },
+            'oldPath': oldPath,
+            'currentPath': self.b_path,
+            'addLines': self.added,
+            'delLines': self.removed,
+            'type': changeType,
+            'fileType': self.FILE_BINARY if self.binary else self.FILE_TEXT,
+            'hunks': [hunk.to_conduit(conduit) for hunk in self.hunks],
+        }
+
+
+class Diff:
+    """simple diff parser"""
+    def __init__(self, commit):
+        self.commit = commit
+        self.changes = {}
+
+        # Get a combined raw & patch diff from git diff-tree. The sections will
+        # be separated by '\0\0'.
+        [raw, patch] = check_output([
+            'git', 'diff-tree', '-r',
+            '--no-ext-diff', '--no-textconv', '--no-color', # No customization
+            '--raw', '-z',        # Add easy-to-parse \0-separated header
+            '--patch', '-U32767', # Include all patch context
+            '--full-index',       # Don't abbreviate the index sha1s
+            commit.commit_hash
+        ]).decode().split('\0\0', maxsplit=1)
+
+        # Split the raw section on '\0:', the delimiter between raw changes
+        [junk, *raw_changes] = raw.split('\0:')
+        assert junk == commit.commit_hash, "unexpected junk leader!"
+        for change in raw_changes:
+            # '--raw -z' only uses '\0' to split paths, other sections are still
+            # space-separated.
+            [fields, a_path, *rest] = change.split('\0')
+            [a_mode, b_mode, a_hash, b_hash, kind] = fields.split(' ')
+
+            # Determine which paths we are working with.
+            b_path = a_path
+            if len(rest) == 1:
+                b_path = rest[0]
+
+            # Create the change for this raw change.
+            key = f"{a_hash}..{b_hash}"
+            self.changes[key] = \
+                Change(a_mode, b_mode, a_hash, b_hash, kind, a_path, b_path)
+
+        # Walk through lines in the patch. Reading an 'index' line will switch
+        # to a new diff entry.
+        active_change = None
+        active_hunk = None
+        a_hunk_remaining = 0
+        b_hunk_remaining = 0
+        for line in patch.splitlines():
+            # Check for entering a new entry's header
+            indexmatch = re.match(r'index ([a-f0-9]{40}..[a-f0-9]{40})', line, re.I)
+            if indexmatch:
+                active_change = self.changes[indexmatch.group(1)]
+                continue
+            elif active_change is None:
+                continue
+
+            # Detect binary diffs
+            if line.startswith('Binary files'): # XXX(nika): more robust?
+                assert len(active_change.hunks) == 0, "binary files have no hunks"
+                active_change.binary = True
+            if active_change.binary:
+                continue
+
+            # Detect hunks
+            hunkmatch = re.match(r'@@ -(\d+),(\d+) \+(\d+),(\d+) @@', line, re.I)
+            if hunkmatch:
+                active_hunk = Hunk(int(hunkmatch.group(1)),
+                                   int(hunkmatch.group(2)),
+                                   int(hunkmatch.group(3)),
+                                   int(hunkmatch.group(4)))
+                active_change.hunks.append(active_hunk)
+
+                # Keep track of how many lines are remaining for each hunk.
+                a_hunk_remaining = active_hunk.a_length
+                b_hunk_remaining = active_hunk.b_length
+                continue
+            elif active_hunk is None:
+                continue
+
+            # Add additions, removals, and context to the current hunk.
+            if line[0] == '+':
+                assert b_hunk_remaining > 0
+                active_change.added += 1
+                b_hunk_remaining -= 1
+                active_hunk.corpus.append(line)
+
+            if line[0] == '-':
+                assert a_hunk_remaining > 0
+                active_change.removed += 1
+                a_hunk_remaining -= 1
+                active_hunk.corpus.append(line)
+
+            if line[0] == ' ':
+                a_hunk_remaining -= 1
+                b_hunk_remaining -= 1
+                active_hunk.corpus.append(line)
+
+            # If we've seen all of the lines for the current hunk, end it.
+            if a_hunk_remaining == 0 and b_hunk_remaining == 0:
+                active_hunk = None
+
+    def to_conduit(self, conduit):
+        changes = [ch.to_conduit(conduit) for ch in self.changes.values()]
+        return conduit.do('differential.creatediff',
+                          changes=changes,
+                          sourceMachine=conduit.hostname,
+                          # XXX(nika): say git if non-public commit?
+                          sourceControlSystem='hg',
+                          sourceControlPath='',
+                          sourceControlBaseRevision=self.commit.parent().hg_hash,
+                          creationMethod='phlay',
+                          lintStatus='none',
+                          unitStatus='none',
+                          repositoryPHID=conduit.repository['phid'],
+
+                          # XXX(nika): Why send this?
+                          sourcePath=conduit.top,
+                          # XXX(nika): This seems kinda irrelevant?
+                          branch='HEAD')
 
 
 class Cached:
@@ -164,6 +378,24 @@ class User(Cached):
         return self._info
 
 
+class Blob(Cached):
+    null_hash = '0' * 40
+    _body = None
+
+    def init(self, hash):
+        self.hash = hash
+
+    def is_null(self):
+        return self.hash == self.null_hash
+
+    def body(self):
+        if self.is_null():
+            return None
+        if self._body is None:
+            self._body = check_output('git', 'cat-file', 'blob', self.hash)
+        return self._body
+
+
 class Commit(Cached):
     # Fields pulled from 'git show'
     abbrev          = '%h'
@@ -219,13 +451,21 @@ class Commit(Cached):
             rev_replace, self.body, count=1, flags=re.I | re.M
         ).strip()
 
+        # Check if this commit has a corresponding hg revision
+        try:
+            self.hg_hash = check_output(['git', 'cinnabar', 'git2hg',
+                                         self.commit_hash])
+        except CalledProcessError:
+            self.hg_hash = '0' * 40 # XXX: uhh? do better?
+
+
     def parent(self):
         if len(self.parent_hashes) == 1:
             return Commit(self.parent_hashes[0])
         return None
 
     def get_diff(self):
-        return check_output([
+        return Diff(check_output([
             'git', 'diff-tree',
             '--no-ext-diff',
             '--no-textconv',
@@ -233,9 +473,10 @@ class Commit(Cached):
             '--no-color',
             '--src-prefix=a/',
             '--dst-prefix=b/',
+            '--patch-with-raw',
             '-U32767',
             self.commit_hash
-        ]).decode()
+        ]).decode())
 
     def add_transaction(self, type, value):
         self.transactions.append({
@@ -430,11 +671,7 @@ def process_args(args):
             if txn['type'] == 'summary':
                 txn['value'] = commit.summary(parent=parent)
 
-        # XXX(nika): Use 'differential.creatediff' instead to get full
-        # flexibility.
-        diff = conduit.do('differential.createrawdiff',
-                          diff=commit.get_diff(),
-                          repositoryPHID=conduit.repository['phid'])
+        diff = commit.get_diff().to_conduit(conduit)
         label('Diff URI', diff['uri'])
         commit.add_transaction('update', diff['phid'])
 


### PR DESCRIPTION
The diffparser branch contains a local diff parser, and other stuff, including:

- [x] Local diff parser, providing more detailed diff understanding #6 
- [x] Specifying projects as reviewers in `r=` #8 
- [x] Support for base revisions on diffs #6 
- [x] Commit authorship & time info for lando #7 
- [x] Accurate mercurial hashes for non-public commits #10 
- [x] Simple mercurial bundle parser to extract changeset details #10 
- [x] Improved binary file support #6 
- [x] Support for moved and copied files in the diff parser #12 
- [x] Support for images & correct MIME types
- [x] Visualization of changes to be sent
- [x] Complete local commit information
- [x] Accurate linting support
- [x] Move/Copy/Multicopy support
- [x] Simplified styling API
- [x] Automatic token login prompt for users without arcanist
- [x] Cleaner revision titles (without r=)
- [x] All diffs uploaded before revisions updated (more atomic commits)
- [x] Improved dependency behaviour (based on push)

Fixes #12, #14, #17, #18, #19, #20