### PR TITLE
Handle Windows path returned from git when running phlay in Windows Subsystem for Linux.

### DIFF
--- a/phlay
+++ b/phlay
@@ -63,14 +63,17 @@ class Conduit:
         # Load the global and local Arcanist configuration
         git_top = (check_output(['git', 'rev-parse', '--show-toplevel'])
                    .decode().strip())
-        if (len(git_top) > 2 and git_top[0].isalpha() and git_top[1] == ":" and
-                os.path.exists("/bin/wslpath")):
-            # Git returned a Windows path, but phlay is running in WSL.
-            # Therefore, we must translate the path to a WSL path.
-            self.top = Path(check_output(['/bin/wslpath', git_top]).decode()
-                            .strip())
-        else:
+        if git_top.startswith('/'):
             self.top = Path(git_top)
+        else:
+            # This is probably a Windows path.
+            # If we're in WSL, this needs to be converted.
+            try:
+                self.top = Path(check_output(['/bin/wslpath', git_top]).decode()
+                                .strip())
+            except FileNotFoundError:
+                # Probably not in WSL.
+                self.top = Path(git_top)
         with open(self.top / '.arcconfig') as f:
             arcconfig = json.load(f)
 

--- a/phlay
+++ b/phlay
@@ -61,8 +61,16 @@ class UserError(Exception):
 class Conduit:
     def __init__(self, arcrc_path):
         # Load the global and local Arcanist configuration
-        self.top = Path(check_output(['git', 'rev-parse', '--show-toplevel'])
-                        .decode().strip())
+        git_top = (check_output(['git', 'rev-parse', '--show-toplevel'])
+                   .decode().strip())
+        if (len(git_top) > 2 and git_top[0].isalpha() and git_top[1] == ":" and
+                os.path.exists("/bin/wslpath")):
+            # Git returned a Windows path, but phlay is running in WSL.
+            # Therefore, we must translate the path to a WSL path.
+            self.top = Path(check_output(['/bin/wslpath', git_top]).decode()
+                            .strip())
+        else:
+            self.top = Path(git_top)
         with open(self.top / '.arcconfig') as f:
             arcconfig = json.load(f)
 


### PR DESCRIPTION
Because WSL file system access is slow, it might be necessary to use Windows git instead of WSL git for large repositories; e.g. mozilla-central.
However, you might still wish to run most tools (including phlay) directly in WSL.
In this case, paths returned from git will be Windows paths, but phlay needs a Unix path for the top level directory.
Therefore, detect this case and translate the path using wslpath.

This is a rather obscure use case (most people would either run everything in WSL or everything in Windows), so I totally understand if you don't want to merge this. However, I thought I'd submit it anyway in case it's useful to someone else.