### PR TITLE
Add support for Windows

### DIFF
--- a/phlay
+++ b/phlay
@@ -7,13 +7,18 @@ import sys
 import os
 import re
 import json
-import curses
 import base64
 import socket
 import difflib
 import mimetypes
 import textwrap
 import shlex
+
+try:
+  # No curses support on Windows
+  import curses
+except ImportError:
+  curses = None
 
 from distutils.version import StrictVersion
 from http.client import HTTPSConnection, HTTPException
@@ -41,7 +46,7 @@ class Style:
 
     def __init__(self, color, stream=sys.stdout):
         dumb = os.environ.get("TERM") == "dumb"
-        self.styled = color == 'always' or (color == 'auto' and stream.isatty() and not dumb)
+        self.styled = curses and (color == 'always' or (color == 'auto' and stream.isatty() and not dumb))
         if self.styled:
             curses.setupterm()
             self._setf = curses.tigetstr('setaf') or curses.tigetstr('setf')


### PR DESCRIPTION
With this patch applied, I could use phlay successfully on Windows inside a mozilla-build shell.