### PR TITLE
Set parent revision if the parent commit has a revision and is for th…

### DIFF
--- a/phlay
+++ b/phlay
@@ -852,7 +852,9 @@ def process_args(args):
         print(style.bold_yellow(f"Requesting Review"), f"{commit.subject}")
 
         # Update dependency relationships if needed.
-        pphids = [] if idx == 0 else [parent.revision.info(conduit)['phid']]
+        pphids = []
+        if parent.bug == commit.bug and parent.revision:
+            pphids.append(parent.revision.info(conduit)['phid'])
         if commit.revision is None or pphids != commit.revision.edges(conduit):
             commit.add_transaction('parents.set', pphids)
 


### PR DESCRIPTION
…e same bug

A typical case is to have multiple commits for a single bug, and when
some of them need updates after review, one may want to update only
those revisions rather than the whole stack.

When doing so, parent information is then lost. With this change, the
parent information is preserved, if the commit that is parent of the
start of the processed range is for the same bug and has a revision
in its commit message.