### PR TITLE
Treat a modified BMO ID as a warning rather than an error

### DIFF
--- a/phlay
+++ b/phlay
@@ -806,8 +806,11 @@ def process_args(args):
                 raise UserError('mismatched revision repository ' +
                                 revfields['repositoryPHID'])
             if revfields['bugzilla.bug-id'] != str(commit.bug.bugno):
-                raise UserError('mismatched bug # ' +
-                                revfields['bugzilla.bug-id'])
+                warn(commit,
+                     "mismatched bug ID. Changing from " +
+                     f"{revfields['bugzilla.bug-id'] or '<none>'} to " +
+                     f"{commit.bug.bugno}")
+                commit.add_transaction('bugzilla.bug-id', str(commit.bug.bugno))
 
         # If the initial commit has parents which match local repository state,
         # preserve them, allowing users to push a single commit without pushing


### PR DESCRIPTION
Examples where it is useful to change BMO ID:

- Take over non-phlay patch without BMO ID and add a BMO ID.
- Move revisions to a different bug.

Example of revision update that was created after this patch: https://phabricator.services.mozilla.com/D31496#1016748
(Note the `robwu added Bugzilla Bug ID 1551490.` message)