### PR TITLE
Include 'rev' field in "local:commits" metadata

### DIFF
--- a/phlay
+++ b/phlay
@@ -456,7 +456,7 @@ class Diff:
                    diff_id=diff['diffid'],
                    name='local:commits',
                    data=json.dumps({
-                       self.commit.hg_hash: {
+                       self.commit.commit_hash: {
                            'author': self.commit.author_name,
                            'authorEmail': self.commit.author_email,
                            'time': int(self.commit.unix_date),
@@ -465,6 +465,7 @@ class Diff:
                            'commit': self.commit.hg_hash,
                            'tree': self.commit.tree_hash,
                            'parents': [self.commit.parent().hg_hash],
+                           'rev': self.commit.commit_hash,
                        }
                    }))
 


### PR DESCRIPTION
Pushes to phabricator with phlay were failing due to the hg-specific 'rev' field
missing from the "local:commits" metadata used by lando. This field was
populated by moz-phab, but not by phlay.

Mimicing the behaviour used by moz-phab, this field contains the git commit
hash, rather than the mercurial one, although commits being submitted are
generally unlikely to have a mercurial hash in the first place.

Fixes #72 