### PR TITLE
Support git checkouts without git-cinnabar on Linux/macOS

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,5 @@
+* Support git checkouts without git-cinnabar on Linux and macOS too
+
 # Version 0.2.4
 
 * Fixed various diff generation issues when adding empty files. (https://github.com/mystor/phlay/pull/76)

--- a/phlay
+++ b/phlay
@@ -663,7 +663,7 @@ class Commit(Cached):
             # '--hg-bundle' is passed, this will be corrected before pushing.
             if self.hg_hash == NULL_SHA1:
                 self.hg_hash = self.commit_hash
-        except FileNotFoundError:
+        except (CalledProcessError, FileNotFoundError):
             # Handle git-cinnabar being uninstalled
             self.hg_hash = self.commit_hash
 


### PR DESCRIPTION
Support for non-cinnabar environments was introduced before in c7297127aba7a5eb776a0f40b9cb167265b0516f, but that only works on Windows. This patch expands support to Linux and macOS.

The logic here also matches what is documented at https://docs.python.org/3/library/subprocess.html#exceptions :

> check_call() and check_output() will raise CalledProcessError if the called process returns a non-zero return code.

P.S. I successfully used `phlay` to get a patch submitted from a minimal git repo that only consisted of the modified files (+`.arcconfig` from mozilla-central). `moz-phab` required `git-cinnabar`, phlay did not (well at least with this patch it does not)!